### PR TITLE
:bug: Error handling is now done via a 🌎 global called `errorDetail`

### DIFF
--- a/src/components/Pages/DiagnosticPage.tsx
+++ b/src/components/Pages/DiagnosticPage.tsx
@@ -1,5 +1,6 @@
 import React, {useGlobal} from 'reactn';
 import {Alert} from "react-bootstrap";
+import {useEffect} from "react";
 
 interface IProps {
     error: any
@@ -15,6 +16,24 @@ const DiagnosticPage = (props: IProps): JSX.Element | null => {
     const [development] = useGlobal('development');
     const error = props.error;
 
+    useEffect(() => {
+        const el = document.getElementById('landing-page-tabs-tab-error');
+        if (error) {
+            if (el) {
+                el.style.color = '#007BFF';
+            }
+        } else {
+            if (el) {
+                el.style.color = 'white';
+            }
+        }
+    }, [error])
+
+    // No error then don't render.
+    if (!error) {
+        return null;
+    }
+
     /**
      * Function to create the unsafe HTML object
      * @param {string} html
@@ -24,7 +43,18 @@ const DiagnosticPage = (props: IProps): JSX.Element | null => {
         return {__html: html}
     };
 
-    let content;
+    const alert = (message: string) => {
+        return (
+            <Alert variant="danger">
+                <Alert.Heading>
+                    Error
+                </Alert.Heading>
+                {message}
+            </Alert>
+        )
+    }
+
+    let content: {} | null | undefined;
     if (error && development) {
         console.log('Error', error);
         if (error instanceof Object && error.text) {
@@ -32,27 +62,21 @@ const DiagnosticPage = (props: IProps): JSX.Element | null => {
             if (contentType.includes('html')) {
                 content = (<div dangerouslySetInnerHTML={createMarkup(error.text)}/>);
             } else {
-                content = (<p>{error.text}</p>)
+                if (error instanceof String && error.toLowerCase().includes('html')) {
+                    content = (<div dangerouslySetInnerHTML={createMarkup(error as string)}/>);
+                } else {
+                    content = alert(error?.text || 'unknown error - see console log. Error type: ' + typeof error);
+                }
             }
         } else {
-            content = (
-                <Alert variant='danger'>
-                    <Alert.Heading>
-                        Unknown Error
-                    </Alert.Heading>
-                    Check the console log for details.
-                </Alert>
-            );
+            if (error instanceof String && error.toLowerCase().includes('html')) {
+                content = (<div dangerouslySetInnerHTML={createMarkup(error as string)}/>);
+            } else {
+                content = alert(error?.text || 'unknown error - see console log. Error type: ' + typeof error);
+            }
         }
     } else {
-        content = (
-            <Alert variant="danger">
-                <Alert.Heading>
-                    Error
-                </Alert.Heading>
-                Something went wrong. Check your internet connection and try again.
-            </Alert>
-        );
+        content = alert('Something went wrong. Check your internet connection and try again.');
     }
     return <>{content}</>;
 }

--- a/src/components/Pages/LoginPage.tsx
+++ b/src/components/Pages/LoginPage.tsx
@@ -9,7 +9,6 @@ import TabContent from '../../styles/common.css';
 
 interface IProps {
     activeTabKey: string | null
-    onError: (e: Error) => void
     onLogin: (loggedIn: boolean) => void
 }
 
@@ -24,6 +23,7 @@ const LoginPage = (props: IProps): JSX.Element => {
     const [, setOtcList] = useGlobal('otcList');
     const [, setResidentList] = useGlobal('residentList');
     const [apiKey, setApiKey] = useGlobal('apiKey');
+    const [, setErrorDetails] = useGlobal('errorDetails');
     const [am] = useGlobal('authManager');
     const [mm] = useGlobal('medicineManager');
     const [password, setPassword] = useState('');
@@ -34,7 +34,6 @@ const LoginPage = (props: IProps): JSX.Element => {
     const focusRef = useRef<HTMLInputElement>(null);
     const {
         activeTabKey,
-        onError,
         onLogin
     } = props;
 
@@ -67,7 +66,7 @@ const LoginPage = (props: IProps): JSX.Element => {
                         // Load ALL OTC medications
                         mm.loadOtcList()
                             .then((otcDrugs) => setOtcList(otcDrugs))
-                            .catch(() => setOtcList([]));
+                            .catch((err) => setErrorDetails(err));
 
                         // Let the parent component know we are logged in successfully
                         onLogin(true);
@@ -88,7 +87,7 @@ const LoginPage = (props: IProps): JSX.Element => {
                 }
             })
             .catch((err) => {
-                onError(err);
+                setErrorDetails(err);
             });
     }
 
@@ -98,10 +97,16 @@ const LoginPage = (props: IProps): JSX.Element => {
      * @param {React.MouseEvent<HTMLElement>} e
      */
     const logout = (e: React.MouseEvent<HTMLElement>) => {
-        e.preventDefault();
+        e.persist();
         setGlobal(getInitialState())
             .then(() => console.log('logout successful'))
-            .catch((err) => onError(err))
+            .then(() => {
+                if (e.ctrlKey) {
+                    console.log('Error handler testing');
+                    throw new Error('Testing the error handler.');
+                }
+            })
+            .catch((err) => setErrorDetails(err))
     }
 
     const signIn = (

--- a/src/components/Pages/ManageDrugPage.tsx
+++ b/src/components/Pages/ManageDrugPage.tsx
@@ -8,24 +8,20 @@ import {Alert} from "react-bootstrap";
 import {getMDY} from "../../utility/common";
 import {MedicineRecord, newDrugInfo} from "../../types/RecordTypes";
 
-interface IProps {
-    onError: (e: Error) => void
-}
 
 /**
  * ManageDrugPage
  * Page for Displaying, editing and adding Medicine
- *
  * @returns {JSX.Element}
  */
-const ManageDrugPage = (props: IProps): JSX.Element => {
+const ManageDrugPage = (): JSX.Element => {
+    const [, setErrorDetails] = useGlobal('errorDetails');
     const [activeResident] = useGlobal('activeResident');
     const [medicineInfo, setMedicineInfo] = useState<MedicineRecord | null>(null);
     const [medicineList, setMedicineList] = useGlobal('medicineList');
     const [mm] = useGlobal('medicineManager');
     const [showDeleteMedicine, setShowDeleteMedicine] = useState(false);
     const [showMedicineEdit, setShowMedicineEdit] = useState(false);
-    const onError = props.onError;
 
     /**
      * Fires when the Edit button is clicked
@@ -71,10 +67,10 @@ const ManageDrugPage = (props: IProps): JSX.Element => {
                         .then((medicineRecords) => {
                             setMedicineList(medicineRecords);
                         })
-                            .catch((err) => onError(err));
+                            .catch((err) => setErrorDetails(err));
                     }
                 })
-                .catch((err) => onError(err));
+                .catch((err) => setErrorDetails(err));
     }
 
     return (
@@ -140,7 +136,7 @@ const ManageDrugPage = (props: IProps): JSX.Element => {
                                     mm.loadMedicineList(activeResident?.Id as number)
                                         .then((medicines) => setMedicineList(medicines))
                                 })
-                                .catch((err) => onError(err))
+                                .catch((err) => setErrorDetails(err))
                         }
                     }}
                     drugInfo={medicineInfo}

--- a/src/components/Pages/ManageOtcPage.tsx
+++ b/src/components/Pages/ManageOtcPage.tsx
@@ -7,24 +7,18 @@ import TooltipButton from "../Buttons/TooltipButton";
 import {Alert} from "react-bootstrap";
 import {MedicineRecord, newDrugInfo} from "../../types/RecordTypes";
 
-interface IProps {
-    onError: (e: Error) => void
-}
-
 /**
  * ManageOtcPage
  * Page for Displaying, editing and adding OTC drugs
- *
- * @param {IProps} props
  * @returns {JSX.Element}
  */
-const ManageOtcPage = (props: IProps): JSX.Element => {
+const ManageOtcPage = (): JSX.Element => {
     const [medicineInfo, setMedicineInfo] = useState<MedicineRecord | null>(null);
     const [mm] = useGlobal('medicineManager');
     const [otcList, setOtcList] = useGlobal('otcList');
     const [showDeleteMedicine, setShowDeleteMedicine] = useState(false);
     const [showMedicineEdit, setShowMedicineEdit] = useState(false);
-    const onError = props.onError;
+    const [, setErrorDetails] = useGlobal('errorDetails');
 
     /**
      * Fires when the Edit button is clicked
@@ -134,7 +128,7 @@ const ManageOtcPage = (props: IProps): JSX.Element => {
                                     mm.loadOtcList()
                                         .then((otcDrugs) => setOtcList(otcDrugs))
                                 })
-                                .catch((err) => onError(err))
+                                .catch((err) => setErrorDetails(err))
                         }
                     }}
                     drugInfo={medicineInfo}

--- a/src/components/Pages/MedicinePage.tsx
+++ b/src/components/Pages/MedicinePage.tsx
@@ -26,7 +26,6 @@ import {
 
 interface IProps {
     activeTabKey: string | null
-    onError: (e: Error) => void
 }
 
 /**
@@ -37,23 +36,23 @@ interface IProps {
  * @return {JSX.Element | null}
  */
 const MedicinePage = (props: IProps): JSX.Element | null => {
-    const [showMedicineEdit, setShowMedicineEdit] = useState(false);
-    const [showDrugLog, setShowDrugLog] = useState(false);
-    const [medicineInfo, setMedicineInfo] = useState<MedicineRecord | null>(null);
-    const [drugLogInfo, setDrugLogInfo] = useState<DrugLogRecord | null>(null);
-    const [showDeleteDrugLogRecord, setShowDeleteDrugLogRecord] = useState<any>(false);
-    const [lastTaken, setLastTaken] = useState<number | null>(null);
+    const [, setErrorDetails] = useGlobal('errorDetails');
     const [activeDrug, setActiveDrug] = useState<MedicineRecord | null>(null);
-    const [searchText, setSearchText] = useState('');
-    const [searchIsValid, setSearchIsValid] = useState(false)
-    const [medicineList, setMedicineList] = useGlobal('medicineList');
-    const [drugLogList, setDrugLogList] = useGlobal('drugLogList');
     const [activeResident] = useGlobal('activeResident');
+    const [drugLogInfo, setDrugLogInfo] = useState<DrugLogRecord | null>(null);
+    const [drugLogList, setDrugLogList] = useGlobal('drugLogList');
+    const [lastTaken, setLastTaken] = useState<number | null>(null);
+    const [medicineInfo, setMedicineInfo] = useState<MedicineRecord | null>(null);
+    const [medicineList, setMedicineList] = useGlobal('medicineList');
     const [mm] = useGlobal('medicineManager');
     const [residentId, setResidentId] = useState<number | null>(activeResident?.Id || null);
-    const focusRef = useRef<HTMLInputElement>(null);
-    const onError = props.onError;
+    const [searchIsValid, setSearchIsValid] = useState(false)
+    const [searchText, setSearchText] = useState('');
+    const [showDeleteDrugLogRecord, setShowDeleteDrugLogRecord] = useState<any>(false);
+    const [showDrugLog, setShowDrugLog] = useState(false);
+    const [showMedicineEdit, setShowMedicineEdit] = useState(false);
     const activeTabKey = props.activeTabKey;
+    const focusRef = useRef<HTMLInputElement>(null);
 
     // Set the activeDrug when the medicineList changes or the activeResident.
     useEffect(() => {
@@ -147,11 +146,9 @@ const MedicinePage = (props: IProps): JSX.Element | null => {
                         setMedicineList(meds);
                         setActiveDrug(drugRecord);
                     })
-                    .catch((err) => {
-                        onError(err);
-                    });
+                    .catch((err) => setErrorDetails(err));
             })
-            .catch((err) => onError(err));
+            .catch((err) => setErrorDetails(err));
     }
 
     /**
@@ -163,12 +160,12 @@ const MedicinePage = (props: IProps): JSX.Element | null => {
             .then((deleted) => {
                 if (deleted.success) {
                     mm.loadDrugLog(residentId).then((drugs) => setDrugLogList(drugs))
-                        .catch((err) => onError(err))
+                        .catch((err) => setErrorDetails(err))
                 } else {
                     throw new Error('DrugLog Delete failed for MedHistory.Id: ' + drugLogId);
                 }
             })
-            .catch((err) => onError(err));
+            .catch((err) => setErrorDetails(err));
     }
 
     /**
@@ -206,7 +203,7 @@ const MedicinePage = (props: IProps): JSX.Element | null => {
             };
             mm.updateDrugLog(drugLogInfo, residentId)
                 .then((drugLogList) => setDrugLogList(drugLogList))
-                .catch((err) => onError(err))
+                .catch((err) => setErrorDetails(err))
         }
     }
 
@@ -362,7 +359,7 @@ const MedicinePage = (props: IProps): JSX.Element | null => {
                         if (drugLogRecord) {
                             mm.updateDrugLog(drugLogRecord, residentId)
                                 .then((drugLogList) => setDrugLogList(drugLogList))
-                                .catch((err) => onError(err))
+                                .catch((err) => setErrorDetails(err))
                         }
                     }}
                 />

--- a/src/components/Pages/OtcPage.tsx
+++ b/src/components/Pages/OtcPage.tsx
@@ -23,7 +23,6 @@ import {
 
 interface IProps {
     activeTabKey: string | null
-    onError: (e: Error) => void
 }
 
 /**
@@ -33,24 +32,24 @@ interface IProps {
  * @returns {JSX.Element | null}
  */
 const OtcPage = (props: IProps): JSX.Element | null => {
-    const [drugInfo, setDrugInfo] = useState<MedicineRecord | null>(null);
-    const [showMedicineEdit, setShowMedicineEdit] = useState(false);
-    const [showDrugLog, setShowDrugLog] = useState(false);
-    const [drugLogInfo, setDrugLogInfo] = useState<DrugLogRecord | null>(null);
-    const [showDeleteDrugLogRecord, setShowDeleteDrugLogRecord] = useState<any>(false);
-    const [lastTaken, setLastTaken] = useState<number | null>(null);
-    const [searchText, setSearchText] = useState('');
-    const [searchIsValid, setSearchIsValid] = useState<boolean | null>(null);
+    const [, setErrorDetails] = useGlobal('errorDetails');
     const [activeDrug, setActiveDrug] = useState<MedicineRecord | null>(null);
-    const [otcLogList, setOtcLogList] = useState<DrugLogRecord[]>([]);
-    const [otcList, setOtcList] = useGlobal('otcList');
-    const [drugLogList, setDrugLogList] = useGlobal('drugLogList');
     const [activeResident] = useGlobal('activeResident');
+    const [drugInfo, setDrugInfo] = useState<MedicineRecord | null>(null);
+    const [drugLogInfo, setDrugLogInfo] = useState<DrugLogRecord | null>(null);
+    const [drugLogList, setDrugLogList] = useGlobal('drugLogList');
+    const [lastTaken, setLastTaken] = useState<number | null>(null);
     const [mm] = useGlobal('medicineManager');
+    const [otcList, setOtcList] = useGlobal('otcList');
+    const [otcLogList, setOtcLogList] = useState<DrugLogRecord[]>([]);
     const [residentId, setResidentId] = useState(activeResident && activeResident.Id);
-    const focusRef = useRef<HTMLInputElement>(null);
+    const [searchIsValid, setSearchIsValid] = useState<boolean | null>(null);
+    const [searchText, setSearchText] = useState('');
+    const [showDeleteDrugLogRecord, setShowDeleteDrugLogRecord] = useState<any>(false);
+    const [showDrugLog, setShowDrugLog] = useState(false);
+    const [showMedicineEdit, setShowMedicineEdit] = useState(false);
     const activeTabKey = props.activeTabKey;
-    const onError = props.onError;
+    const focusRef = useRef<HTMLInputElement>(null);
 
     // We only want to list the OTC drugs on this page that the resident has taken.
     useEffect(() => {
@@ -149,7 +148,7 @@ const OtcPage = (props: IProps): JSX.Element | null => {
                         setActiveDrug(drugRecord);
                     })
                     .catch((err) => {
-                        onError(err);
+                        setErrorDetails(err);
                     });
             });
     }
@@ -163,12 +162,12 @@ const OtcPage = (props: IProps): JSX.Element | null => {
                 .then((deleted) => {
                     if (deleted.success) {
                         mm.loadDrugLog(residentId).then((drugs) => setDrugLogList(drugs))
-                            .catch((err) => onError(err));
+                            .catch((err) =>setErrorDetails(err));
                     } else {
                         throw new Error('DrugLog Delete failed for Record: ' + drugLogId);
                     }
                 })
-                .catch((err) => onError(err));
+                .catch((err) => setErrorDetails(err));
     }
 
     /**
@@ -206,7 +205,7 @@ const OtcPage = (props: IProps): JSX.Element | null => {
             };
             mm.updateDrugLog(drugLogInfo, residentId)
                 .then((drugs) => setDrugLogList(drugs))
-                .catch((err) => onError(err))
+                .catch((err) => setErrorDetails(err))
         }
     }
 
@@ -356,7 +355,7 @@ const OtcPage = (props: IProps): JSX.Element | null => {
                         if (drugLogRecord) {
                             mm.updateDrugLog(drugLogRecord, residentId)
                                 .then((drugLogList) => setDrugLogList(drugLogList))
-                                .catch((err) => onError(err))
+                                .catch((err) => setErrorDetails(err))
                         }
                         setShowDrugLog(false);
                     }}

--- a/src/components/Pages/ResidentPage.tsx
+++ b/src/components/Pages/ResidentPage.tsx
@@ -7,20 +7,16 @@ import {Alert, Form} from "react-bootstrap";
 import {FullName} from '../../utility/common';
 import {ResidentRecord} from "../../types/RecordTypes";
 
-interface IProps {
-    onError: (e: Error) => void
-}
 
 /**
  * Display Resident Grid
  * Allow user to edit and add Residents
- *
- * @param {IProps} props
  * @return {JSX.Element}
  * @constructor
  */
-const ResidentPage = (props: IProps): JSX.Element => {
+const ResidentPage = (): JSX.Element => {
     const [, setDrugLogList] = useGlobal('drugLogList');
+    const [, setErrorDetails] = useGlobal('errorDetails');
     const [, setMedicineList] = useGlobal('medicineList');
     const [activeResident, setActiveResident] = useGlobal('activeResident');
     const [mm] = useGlobal('medicineManager');
@@ -30,7 +26,6 @@ const ResidentPage = (props: IProps): JSX.Element => {
     const [rm] = useGlobal('residentManager');
     const [showDeleteResident, setShowDeleteResident] = useState(false);
     const [showResidentEdit, setShowResidentEdit] = useState(false);
-    const onError = props.onError;
 
     /**
      * Fires when user clicks the Edit button
@@ -79,9 +74,9 @@ const ResidentPage = (props: IProps): JSX.Element => {
                         setActiveResident(resident);
                     }
                 })
-                .catch((err) => onError(err))
+                .catch((err) => setErrorDetails(err))
             })
-            .catch((err) => onError(err));
+            .catch((err) => setErrorDetails(err));
     }
 
     /**
@@ -99,9 +94,9 @@ const ResidentPage = (props: IProps): JSX.Element => {
                 setActiveResident(resident);
                 mm.loadDrugLog(residentId)
                     .then((drugs) => setDrugLogList(drugs))
-                    .catch((err) => onError(err))
+                    .catch((err) => setErrorDetails(err))
             })
-            .catch((err) => onError(err))
+            .catch((err) => setErrorDetails(err))
     }
 
     /**
@@ -171,9 +166,9 @@ const ResidentPage = (props: IProps): JSX.Element => {
                                         .then((residents) => setResidentList(residents))
                                 }
                             } else {
-                                onError(new Error('Unable to delete resident.Id ' + residentToDelete.Id));
+                                setErrorDetails(new Error('Unable to delete resident.Id ' + residentToDelete.Id));
                             }
-                        }).catch((err) => onError(err));
+                        }).catch((err) => setErrorDetails(err));
                     }
                 }}
             >

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -19,6 +19,7 @@ declare module 'reactn/default' {
         count: number
         development: boolean
         drugLogList: DrugLogRecord[]
+        errorDetails: any
         medicineList: MedicineRecord[]
         medicineManager: IMedicineManager
         otcList: MedicineRecord[]

--- a/src/utility/getInitialState.ts
+++ b/src/utility/getInitialState.ts
@@ -37,6 +37,7 @@ const getInitialState = () => {
         authManager: AuthManager(providers.authenticationProvider),
         development: process.env.REACT_APP_DEVELOPMENT === 'true',
         drugLogList: [] as DrugLogRecord[],
+        errorDetails: undefined,
         medicineList: [] as MedicineRecord[],
         medicineManager: MedicineMananger(providers.medicineProvider, providers.medHistoryProvider),
         otcList: [] as MedicineRecord[],


### PR DESCRIPTION
All components in the Page directory no loger call `onError()` but instead now use `errorDetails()`
Moved the observer that hides the Diagnostic tab to the DiagnosticPage.tsx
💄Improved the code in DiagnosticPage.tsx to better display errors depending on the type of error. The error prop that DiagnosticPage.tsx receives is of the type `any` so some 🦆 typing logic was added.
global.d.ts and getInitialState.ts were 🔝 updated to handle the new global `errorDetail`
TODO: Make the DiagnosticPage.tsx use an accordion component when showing details. This will be a future task.