### PR TITLE
🥅 DiagnosticPage now resets correctly when dismissed

### DIFF
--- a/src/components/Pages/DiagnosticPage.tsx
+++ b/src/components/Pages/DiagnosticPage.tsx
@@ -66,7 +66,10 @@ const DiagnosticPage = (props: IProps): JSX.Element | null => {
                 <Alert
                     variant="danger"
                     dismissible
-                    onClose={() => dismissError()}
+                    onClose={() => {
+                        setContent(null);
+                        dismissError();
+                    }}
                 >
                     <Alert.Heading>
                         {heading}
@@ -111,7 +114,10 @@ const DiagnosticPage = (props: IProps): JSX.Element | null => {
                     <Card.Footer>
                         <Button
                             variant="primary"
-                            onClick={() => dismissError()}
+                            onClick={() => {
+                                setContent(null);
+                                dismissError();
+                            }}
                         >
                             Close error and sign back in
                         </Button>

--- a/src/components/Pages/LandingPage.tsx
+++ b/src/components/Pages/LandingPage.tsx
@@ -36,6 +36,7 @@ const LandingPage = () => {
             onSelect={(key) => setActiveTabKey(key || 'login')}
         >
             <Tab
+                disabled={errorDetails}
                 eventKey="login"
                 title={<span className={activeTabKey === 'login' ? 'bld' : ''}>{apiKey ? 'Logout' : 'Login'}</span>}
             >

--- a/src/components/Pages/LandingPage.tsx
+++ b/src/components/Pages/LandingPage.tsx
@@ -5,11 +5,11 @@ import ManageDrugPage from "./ManageDrugPage";
 import ManageOtcPage from "./ManageOtcPage";
 import MedicinePage from "./MedicinePage";
 import OtcPage from "./OtcPage";
-import React, {useGlobal, useState} from 'reactn';
+import React, {useEffect, useGlobal, useState, setGlobal} from 'reactn';
 import ResidentPage from "./ResidentPage";
 import Tab from 'react-bootstrap/Tab';
 import Tabs from 'react-bootstrap/Tabs';
-import {useEffect} from "react";
+import getInitialState from "../../utility/getInitialState";
 
 /**
  * Landing Page - Tab Page Menu UI
@@ -19,7 +19,7 @@ const LandingPage = () => {
     const [activeResident] = useGlobal('activeResident');
     const [activeTabKey, setActiveTabKey] = useState('login');
     const [apiKey, setApiKey] = useGlobal('apiKey');
-    const [errorDetails, setErrorDetails] = useGlobal('errorDetails');
+    const [errorDetails] = useGlobal('errorDetails');
 
     // Observer for anytime there is an error set on the errorDetails global
     useEffect(() => {
@@ -107,7 +107,7 @@ const LandingPage = () => {
                     activeTabKey={activeTabKey}
                     error={errorDetails}
                     dismissErrorAlert={() => {
-                        setErrorDetails(undefined);
+                        setGlobal(getInitialState());
                         setActiveTabKey('login');
                     }}
                 />

--- a/src/components/Pages/LoginPage.tsx
+++ b/src/components/Pages/LoginPage.tsx
@@ -109,13 +109,11 @@ const LoginPage = (props: IProps): JSX.Element | null => {
         e.persist();
         setGlobal(getInitialState())
             .then(() => console.log('logout successful'))
-            .then(() => {
-                if (e.ctrlKey) {
-                    console.log('Testing Diagnostics');
-                    throw new Error('Standard Error -- just a test');
-                }
-            })
             .catch((err) => setErrorDetails(err))
+        if (e.ctrlKey) {
+            console.log('Testing Diagnostics');
+            setErrorDetails(new Error('Testing error handler'));
+        }
     }
 
     const signIn = (


### PR DESCRIPTION
- Changed order of operations with LoginPage when testing errors.
- Changed LandingPage handling `dismissErrorAlert()` to set global state back to initial values.