### PR TITLE
🔧 Work-around a 🐛 with ⚛ React 17 and DropdownButton

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "frak": "^3.1.2",
     "lodash": ">=4.17.13",
     "lodash.template": ">=4.5.0",
-    "react": "^16.14.0",
+    "react": "^17.0.1",
     "react-bootstrap": "^1.4.0",
-    "react-dom": "^16.14.0",
+    "react-dom": "^17.0.1",
     "react-scripts": "^3.4.4",
     "reactn": "^2.2.7",
     "typescript": "^4.0.3"

--- a/src/components/ListGroups/DrugDropdown.tsx
+++ b/src/components/ListGroups/DrugDropdown.tsx
@@ -73,8 +73,13 @@ const DrugDropdown = (props: IProps): JSX.Element | null => {
         );
     };
 
+    /**
+     * Work-around so React 17 can be used
+     * @link https://github.com/react-bootstrap/react-bootstrap/issues/5409#issuecomment-718699584
+     */
     return (
         <DropdownButton
+            onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
             size="lg"
             title={title}
             variant="primary"


### PR DESCRIPTION
- Opening a modal breaks DropDownButton when using React 17
- See: https://github.com/react-bootstrap/react-bootstrap/issues/5409
- The work around is here: https://github.com/react-bootstrap/react-bootstrap/issues/5409#issuecomment-718699584
- package.json was changed to bring React ⚛ to v17.0.1