### PR TITLE
ResidentManager fixed 🔧 to prevent dupes

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -24,15 +24,48 @@ const App = () => {
     const residentColor = development ? 'blue' : "#edf11e";
     const residentForegroundColor = development ? "#fffff0" : "black";
 
-    // Initialize all the observers
-    ActiveResidentObserver(activeClient);
-    ApiKeyObserver(providers);
-    ClientObserver();
-    DrugLogObserver(mm, activeClient);
-    ErrorDetailsObserver();
-    AuthObserver();
-    MedicineObserver(mm, activeClient);
-    OtcMedicineObserver(mm);
+    /**
+     * Initialize all the observers
+     * Observers are a type of hybred middleware similar to Publish/Subscribe with intelligent Agents
+     * Below we are "Subscribing" the observers.
+     * The observers themselves are "Intelligent Agents" that use a global state varaible as a "sensor" to
+     * determine what actions need to be taken based on the current state of the machine.
+     * @see https://en.wikipedia.org/wiki/Middleware_(distributed_applications)#Types
+     *
+     * Observers are like functions but instead of accepting arguments they use React's hook mechanisms
+     * to observe changes to a single global state variable. The observer decides the actions to take based on the
+     * values of the global state variable. The global variable for an observer is an object with
+     * the signature of {action: {string}, payload: {any}} with the action string property indicating what action the
+     * observer should perform; the payload property contains any information the observer needs to act on.
+     * Fpr example the ClientObserver is watching for changes to the global `client` variable. If the client variable
+     * isn't null then the observer expects the client variable to be an object with the action property set to one
+     * of three values: 'load', 'update', or 'delete'
+     * If the action is 'load' then the observer will load all client records into the global variable residentList.
+     * If the action is 'update' then the observer will add or update the given client record by what is in the payload.
+     * If the action is 'delete' then the observer will delete the client record indicated by the primary key value in
+     * the payload property.
+     * Advantages:
+     * - Simplicity: Set the observed global variable action and payload then automatically the observer will
+     *               act accordingly.
+     * - Declaritive: Observers are pure functions implemented via React hooks.
+     * - Robust: Due to the declarive nature unexpected side effects & state mutations are minimized.
+     * Disadvantages:
+     * - Abstraction: Instead of importing an observer, a client sets the observed global variable. Unlike importing
+     *                a function which would have a signature it isn't always obvious what action strings and payload
+     *                values are accepatable.
+     * - Flow: Observers react to state changes to the watched global variable so code is excuted similar to events
+     *         when the state changes the code executes as opposed to line-by-line linear processing.
+     * - Not OOP: Observers are pure functions lacking the advantages (and disadvantages) of object oriented
+     *            architecture.
+     */
+    ActiveResidentObserver(activeClient);   // Watching: activeResident
+    ApiKeyObserver(providers);              // Watching: apiKey
+    ClientObserver();                       // Watching: client
+    DrugLogObserver(mm, activeClient);      // Watching: drugLog
+    ErrorDetailsObserver();                 // Watching: errorDetails
+    AuthObserver();                         // Watching: auth
+    MedicineObserver(mm, activeClient);     // Watching: medicine
+    OtcMedicineObserver(mm);                // Watching: otcMedicine
 
     return (
         <>

--- a/src/components/Pages/ResidentPage.tsx
+++ b/src/components/Pages/ResidentPage.tsx
@@ -148,12 +148,18 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
             <ResidentEdit
                 onClose={(residentRecord) => {
                     setShowResidentEdit(false);
-                    setClient({action: "update", payload: residentRecord})
-                    .then(() => {
-                        if (residentRecord?.Id === activeResident?.Id) {
-                            setActiveResident(residentRecord?.Id ? residentRecord : null);
-                        }
-                    })
+                    if (residentRecord) {
+                        setClient({
+                            action: "update",
+                            payload: residentRecord,
+                            cb: (clientRecord) => {
+                                // If we are adding a new resident then make them the active client.
+                                if (!residentRecord.Id) {
+                                    setActiveResident(clientRecord);
+                                }
+                            }
+                        })
+                    }
                 }}
                 residentInfo={residentInfo}
                 show={showResidentEdit}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -18,10 +18,14 @@ declare module 'reactn/default' {
         activeTabKey: string
         apiKey: string | null
         authManager: IAuthManager
-        client: {action: 'load' | 'update' | 'delete', payload: null | ResidentRecord | number} | null
+        client: {
+            action: 'load' | 'update' | 'delete'
+            cb?: (c: ResidentRecord) => void
+            payload: null | ResidentRecord | number
+        } | null
         count: number
         development: boolean
-        drugLog: {action: 'load' | 'update' | 'delete', payload: null | DrugLogRecord | DrugLogRecord[] | number} | null
+        drugLog: {action: 'load'|'update'|'delete', payload?: null | DrugLogRecord | DrugLogRecord[] | number} | null
         drugLogList: DrugLogRecord[]
         errorDetails: any
         login: { username: string, password: string } | null

--- a/src/observers/ApiKeyObserver.ts
+++ b/src/observers/ApiKeyObserver.ts
@@ -4,7 +4,7 @@ import {IProviders} from "../utility/getInitialState";
 /**
  * Watch for changes to the global apiKey
  * when populated it indicates a successful login and triggers
- * a refresh of theresidentList and otcList globals, and sets the active tab page to the ResidentPage tab
+ * a refresh of the residentList and otcList globals, and sets the active tab page to the ResidentPage tab
  * @param {IProviders} providers
  * @constructor
  */
@@ -18,19 +18,20 @@ const ApiKeyObserver = (providers: IProviders) => {
 
     useEffect(() => {
         if (prevApiKey !== apiKey) {
-            // Are we logging in (prevApiKey will be falsy and apiKey will have a value)?
+            // Are we logging in (prevApiKey will be null and apiKey will have a value)?
             if (prevApiKey === null && apiKey) {
                 setLoginFailed(false);
-                providers.setApi(apiKey);
+                providers.setApi(apiKey)
+                .then(() => {
+                    // Load ALL Resident records up front and save them in the global store.
+                    setClient({action: "load", payload: null});
 
-                // Load ALL Resident records up front and save them in the global store.
-                setClient({action: "load", payload: null});
+                    // Load ALL OTC medications once we're logged in.
+                    setOtcMedicine({action: "load", payload: null});
 
-                // Load ALL OTC medications once we're logged in.
-                setOtcMedicine({action: "load", payload: null});
-
-                // Activate the Resident tab
-                setActiveTabKey('resident');
+                    // Activate the Resident tab
+                    setActiveTabKey('resident');
+                })
             }
             return () => {
                 // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/observers/ClientObserver.ts
+++ b/src/observers/ClientObserver.ts
@@ -29,14 +29,13 @@ const ClientObserver = () => {
                     break;
                 }
                 case "update": {
-                    const clientRecord = client.payload as ResidentRecord;
+                    const clientRecord = {...client.payload as ResidentRecord};
                     rm.updateResident(clientRecord)
-                    .then((residentRecord) => {
-                        setClient({action: "load", payload: null});
-                        // When adding a new client set that client as active
-                        if (!clientRecord.Id) {
-                            setActiveResident(residentRecord);
+                    .then((clientRecord) => {
+                        if (client.cb) {
+                            client.cb(clientRecord);
                         }
+                        setClient({action: "load", payload: null});
                     })
                     .catch((err) => setErrorDetails(err))
                     break;

--- a/src/utility/getInitialState.ts
+++ b/src/utility/getInitialState.ts
@@ -13,7 +13,7 @@ export interface IProviders {
     residentProvider: IResidentProvider
     medicineProvider: IMedicineProvider
     medHistoryProvider: IMedHistoryProvider
-    setApi: (apiKey: string) => void
+    setApi: (apiKey: string) => Promise<void>
 }
 
 /**
@@ -30,10 +30,10 @@ const getInitialState = () => {
          * Helper function that sets the API key for ALL providers
          * @param {string} apiKey
          */
-        setApi: (apiKey: string) => {
+        setApi: async (apiKey: string): Promise<void>  => {
             providers.medHistoryProvider.setApiKey(apiKey);
             providers.medicineProvider.setApiKey(apiKey);
-            providers.residentProvider.setApiKey(apiKey)
+            providers.residentProvider.setApiKey(apiKey);
         }
     } as IProviders;
 


### PR DESCRIPTION
- ClientObserver also changed to accept a cb property to initiate a call back with the new client record.
- With the cb feature setting the newly added clients as the active client logic was ♻ refactored moving the logic to ResidentPage instead of in the ClientObserver
- Logic in ResidentManager for updating was vastly simplified by adding a `searchExisting()` function.