### PR TITLE
Fix print margins

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,20 +20,11 @@
     <style type="text/css" media="print">
       @page
       {
-          size:  auto;   /* auto is the initial value */
-          margin: 0mm;  /* this affects the margin in the printer settings */
+          size:  a4;
       }
 
-      html
-      {
-          background-color: #FFFFFF;
-          margin: 0px;  /* this affects the margin on the html before sending to printer */
-      }
-
-      body
-      {
-          border: solid 1px blue ;
-          margin: 10mm 10mm 15mm 10mm; /* margin you want for the content */
+      @page :first {
+        margin-top: 20mm;
       }
     </style>
     <title>℞Chart</title>


### PR DESCRIPTION
- The top of the client name was getting cut off when printing.
- Added a `margin-top: 20mm;` to the first page of any printing.