### PR TITLE
Add Feature to Print Client Roster

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^17.0.1",
     "react-bootstrap": "^1.4.3",
     "react-dom": "^17.0.1",
+    "react-new-window": "^0.1.3",
     "react-scripts": "^4.0.1",
     "reactn": "^2.2.7",
     "typescript": "^4.1.3"

--- a/src/components/Pages/Modals/ClientRoster.tsx
+++ b/src/components/Pages/Modals/ClientRoster.tsx
@@ -1,0 +1,69 @@
+import React, {useEffect, useRef} from 'reactn';
+import NewWindow from "react-new-window";
+import {ResidentRecord} from "../../../types/RecordTypes";
+
+interface IProps {
+    onUnload: () => void
+    clientList: ResidentRecord[]
+}
+
+const ClientRoster = (props: IProps) => {
+    const {
+        onUnload,
+        clientList
+    } = props;
+
+    const newWindow = useRef<NewWindow | null>(null);
+
+    const clientListing = (clientRecord: ResidentRecord) => {
+        return (
+            <li className="no-marker">
+                <h1 style={{lineHeight: "125px", fontSize: "5em"}}>
+                    {clientRecord.LastName}, {clientRecord.FirstName}
+                </h1>
+            </li>
+        )
+    }
+
+    useEffect(() => {
+        if (newWindow && newWindow.current) {
+            const currentWindow = newWindow.current as NewWindow;
+
+            // @ts-ignore TS thinks that the window property is private (nope) so it throws false positive errors.
+            const thisWindow = currentWindow.window as typeof window;
+
+            /**
+             * Handle the afterprint event
+             * @param e {Event} Afterprint event
+             */
+            const handleAfterPrint = (e: Event) => {
+                e.preventDefault();
+
+                // Close this window when we are done printing.
+                thisWindow.close();
+            }
+
+            thisWindow.addEventListener('afterprint', handleAfterPrint);
+            thisWindow.focus();
+            thisWindow.print();
+
+            return () => thisWindow.removeEventListener('afterprint', handleAfterPrint);
+        }
+    }, [newWindow]);
+
+    return (
+        <>
+            <NewWindow
+                title="Print Client Roster"
+                ref={newWindow}
+                onUnload={() => onUnload()}
+            >
+                <ul>
+                    {clientList.map((r) => clientListing(r))}
+                </ul>
+            </NewWindow>
+        </>
+    )
+}
+
+export default ClientRoster;

--- a/src/components/Pages/ResidentPage.tsx
+++ b/src/components/Pages/ResidentPage.tsx
@@ -3,9 +3,10 @@ import React, {useEffect, useGlobal, useRef, useState} from 'reactn';
 import ResidentEdit from './Modals/ResidentEdit';
 import ResidentGrid from './Grids/ResidentGrid';
 import TooltipButton from "../Buttons/TooltipButton";
-import {Alert, Form, Row} from "react-bootstrap";
+import {Alert, Button, Form, Row} from "react-bootstrap";
 import {clientFullName} from '../../utility/common';
 import {ResidentRecord} from "../../types/RecordTypes";
+import ClientRoster from "./Modals/ClientRoster";
 
 interface IProps {
     residentSelected: () => void
@@ -30,6 +31,7 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
     const [searchText, setSearchText] = useState('');
     const [showDeleteResident, setShowDeleteResident] = useState(false);
     const [showResidentEdit, setShowResidentEdit] = useState(false);
+    const [showClientRoster, setShowClientRoster] = useState(false);
     const focusRef = useRef<HTMLInputElement>(null);
     const onSelected = props.residentSelected;
 
@@ -123,6 +125,22 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
                     placeholder="Search resident"
                     ref={focusRef}
                 />
+
+                <Button
+                    className="ml-2"
+                    onClick={(e) => {
+                    e.preventDefault();
+                    setShowClientRoster(true);
+                }}>
+                    Print Client Roster
+                </Button>
+
+                {showClientRoster &&
+                    <ClientRoster
+                        onUnload={() => setShowClientRoster(false)}
+                        clientList={residentList}
+                    />
+                }
             </Row>
 
             <Row className="mt-3">

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -46,3 +46,7 @@ a.hover-underline-animation:hover, a.hover-underline-animation:visited, a.hover-
 {
     text-decoration: none;
 }
+
+li.no-marker::marker {
+    content: none;
+}


### PR DESCRIPTION
- ClientRoster :spiral_notepad:  is in Modals folder but is technically it's own window.
- Added `react-new-window` component so that ClientRoster.tsx can act as its own window.
- To get printing to work See: https://stackoverflow.com/a/67445633/4323201