### PR TITLE
Add Feature to Print Client Roster

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxchart",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "private": true,
   "dependencies": {
     "@types/bwip-js": "^2.0.0",

--- a/src/components/Pages/Modals/ClientRoster.tsx
+++ b/src/components/Pages/Modals/ClientRoster.tsx
@@ -15,7 +15,7 @@ const ClientRoster = (props: IProps) => {
 
     const newWindow = useRef<NewWindow | null>(null);
 
-    const clientListing = (clientRecord: ResidentRecord) => {
+    const clientListItem = (clientRecord: ResidentRecord) => {
         return (
             <li className="no-marker">
                 <h1 style={{lineHeight: "125px", fontSize: "5em"}}>
@@ -59,7 +59,12 @@ const ClientRoster = (props: IProps) => {
                 onUnload={() => onUnload()}
             >
                 <ul>
-                    {clientList.map((r) => clientListing(r))}
+                    {clientList.map((r) => {
+                        return <>
+                            {clientListItem(r)}
+                            {clientListItem(r)}
+                        </>
+                    })}
                 </ul>
             </NewWindow>
         </>

--- a/src/components/Pages/ResidentPage.tsx
+++ b/src/components/Pages/ResidentPage.tsx
@@ -128,10 +128,11 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
 
                 <Button
                     className="ml-2"
+                    disabled={showClientRoster}
                     onClick={(e) => {
-                    e.preventDefault();
-                    setShowClientRoster(true);
-                }}>
+                        e.preventDefault();
+                        setShowClientRoster(true);
+                    }}>
                     Print Client Roster
                 </Button>
 


### PR DESCRIPTION
- ClientRoster is in Modals folder but is technically it's own new ⚡ window.
- Added `react-new-window` component so that ClientRoster.tsx can act as its own window.
- The client name and DOB header was changed to a button when clicked brings up ClientRoster printout for the current client.
- To get printing to work See: https://stackoverflow.com/a/67445633/4323201