### PR TITLE
Fix :wrench: resident record dupe problem

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,3 +1,4 @@
+import About from "./Pages/Modals/About";
 import ActiveResidentObserver from "../observers/ActiveResidentObserver";
 import ApiKeyObserver from "../observers/ApiKeyObserver";
 import AuthObserver from "../observers/AuthObserver";
@@ -8,12 +9,11 @@ import ErrorDetailsObserver from "../observers/ErrorDetailsObserver";
 import LandingPage from "./Pages/LandingPage";
 import MedicineObserver from "../observers/MedicineObserver";
 import OtcMedicineObserver from "../observers/OtcMedicineObserver";
+import PopoverButton from "./Buttons/PopoverButton";
 import React, {useEffect, useGlobal, useState} from 'reactn';
 import TooltipButton from "./Buttons/TooltipButton";
-import {clientDOB, clientFullName} from "../utility/common";
 import {Popover, PopoverTitle} from "react-bootstrap";
-import About from "./Pages/Modals/About";
-import PopoverButton from "./Buttons/PopoverButton";
+import {clientDOB, clientFullName} from "../utility/common";
 
 /**
  * Main Entry Component

--- a/src/components/Pages/ResidentPage.tsx
+++ b/src/components/Pages/ResidentPage.tsx
@@ -22,14 +22,13 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
     const [, setErrorDetails] = useGlobal('__errorDetails');
     const [activeResident, setActiveResident] = useGlobal('activeResident');
     const [activeTabKey] = useGlobal('activeTabKey');
-    const [residentInfo, setResidentInfo] = useState<ResidentRecord | null>(null);
     const [residentList] = useGlobal('residentList');
     const [filteredResidents, setFilteredResidents] = useState<ResidentRecord[]>(residentList);
     const [residentToDelete, setResidentToDelete] = useState<ResidentRecord | null>(null);
     const [searchIsValid, setSearchIsValid] = useState(false);
     const [searchText, setSearchText] = useState('');
     const [showDeleteResident, setShowDeleteResident] = useState(false);
-    const [showResidentEdit, setShowResidentEdit] = useState(false);
+    const [showResidentEdit, setShowResidentEdit] = useState<ResidentRecord | null>(null);
     const [showClientRoster, setShowClientRoster] = useState(false);
     const focusRef = useRef<HTMLInputElement>(null);
     const onSelected = props.residentSelected;
@@ -75,7 +74,7 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
      */
     const handleAddResident = (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
-        setResidentInfo({
+        setShowResidentEdit({
             Id: null,
             FirstName: "",
             LastName: "",
@@ -84,7 +83,6 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
             DOB_DAY: "",
             Notes: ""
         });
-        setShowResidentEdit(true);
     }
 
     /**
@@ -152,8 +150,7 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
                     }
                     onEdit={(e: React.MouseEvent<HTMLElement>, resident: ResidentRecord) => {
                         e.preventDefault();
-                        setResidentInfo({...resident});
-                        setShowResidentEdit(true);
+                        setShowResidentEdit({...resident});
                     }}
                     onSelected={(e: React.MouseEvent<HTMLElement>, resident: ResidentRecord) => {
                         e.preventDefault();
@@ -166,10 +163,8 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
                 />
             </Row>
 
-            {residentInfo &&
             <ResidentEdit
                 onClose={(residentRecord) => {
-                    setShowResidentEdit(false);
                     if (residentRecord) {
                         setClient({
                             action: "update",
@@ -182,11 +177,12 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
                             }
                         })
                     }
+                    setShowResidentEdit(null);
                 }}
-                residentInfo={residentInfo}
-                show={showResidentEdit}
+                residentInfo={showResidentEdit as ResidentRecord}
+                show={showResidentEdit !== null}
             />
-            }
+
 
             {residentToDelete &&
             <Confirm.Modal

--- a/src/components/Pages/ResidentPage.tsx
+++ b/src/components/Pages/ResidentPage.tsx
@@ -5,7 +5,7 @@ import ResidentGrid from './Grids/ResidentGrid';
 import TooltipButton from "../Buttons/TooltipButton";
 import {Alert, Button, Form, Row} from "react-bootstrap";
 import {clientFullName} from '../../utility/common';
-import {ResidentRecord} from "../../types/RecordTypes";
+import {newResidentRecord, ResidentRecord} from "../../types/RecordTypes";
 import ClientRoster from "./Modals/ClientRoster";
 
 interface IProps {
@@ -69,31 +69,14 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
     }
 
     /**
-     * Fires when user clicks the + (add) button
-     * @param {React.MouseEvent<HTMLElement>} e
-     */
-    const handleAddResident = (e: React.MouseEvent<HTMLElement>) => {
-        e.preventDefault();
-        setShowResidentEdit({
-            Id: null,
-            FirstName: "",
-            LastName: "",
-            DOB_YEAR: "",
-            DOB_MONTH: "",
-            DOB_DAY: "",
-            Notes: ""
-        });
-    }
-
-    /**
-     * Fires when user clicks on resident trash icon
-     * @param {React.MouseEvent<HTMLElement>} e
+     * Fires when user clicks on the select button or if the user is trying to add an existing active client
      * @param {ResidentRecord} resident
      */
-    const handleOnDelete = (e: React.MouseEvent<HTMLElement>, resident: ResidentRecord) => {
-        e.preventDefault();
-        setResidentToDelete(resident);
-        setShowDeleteResident(true);
+    const handleOnSelected = (resident: ResidentRecord) => {
+        setActiveResident(resident)
+        .then(() => setSearchText(''))
+        .then(() => onSelected())
+        .catch((err) => setErrorDetails(err))
     }
 
     return (
@@ -103,7 +86,10 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
                     className="mr-2"
                     placement="top"
                     tooltip="Add New Resident"
-                    onClick={(e: React.MouseEvent<HTMLElement>) => handleAddResident(e)}
+                    onClick={(e: React.MouseEvent<HTMLElement>) => {
+                        e.preventDefault();
+                        setShowResidentEdit({...newResidentRecord});
+                    }}
                 >
                     + Resident
                 </TooltipButton>
@@ -145,44 +131,69 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
             <Row className="mt-3">
                 <ResidentGrid
                     activeResident={activeResident}
-                    onDelete={(e: React.MouseEvent<HTMLElement>, resident: ResidentRecord) =>
-                        handleOnDelete(e, resident)
-                    }
+                    residentList={filteredResidents}
+                    onDelete={(e: React.MouseEvent<HTMLElement>, resident: ResidentRecord) => {
+                        e.preventDefault();
+                        setResidentToDelete(resident);
+                        setShowDeleteResident(true);
+                    }}
                     onEdit={(e: React.MouseEvent<HTMLElement>, resident: ResidentRecord) => {
                         e.preventDefault();
                         setShowResidentEdit({...resident});
                     }}
-                    onSelected={(e: React.MouseEvent<HTMLElement>, resident: ResidentRecord) => {
+                    onSelected={(e: React.MouseEvent<HTMLElement>, r: ResidentRecord) => {
                         e.preventDefault();
-                        setActiveResident(resident)
-                        .then(() => setSearchText(''))
-                        .then(() => onSelected())
-                        .catch((err) => setErrorDetails(err))
+                        handleOnSelected(r)
                     }}
-                    residentList={filteredResidents}
                 />
             </Row>
 
             <ResidentEdit
-                onClose={(residentRecord) => {
-                    if (residentRecord) {
-                        setClient({
-                            action: "update",
-                            payload: residentRecord,
-                            cb: (clientRecord) => {
-                                // If we are adding a new resident then make them the active client.
-                                if (!residentRecord.Id) {
-                                    setActiveResident(clientRecord);
-                                }
-                            }
-                        })
-                    }
-                    setShowResidentEdit(null);
-                }}
                 residentInfo={showResidentEdit as ResidentRecord}
                 show={showResidentEdit !== null}
-            />
+                onClose={(client) => {
+                    // Hide this modal
+                    setShowResidentEdit(null);
 
+                    // Do we have a record to update or add?
+                    if (client) {
+                        // Are we adding a new record?
+                        if (client.Id === null) {
+                            // Search residentList for any existing clients to prevent adding dupes
+                            const existing = residentList.find(r =>
+                                r.FirstName.trim().toLowerCase() === client.FirstName.trim().toLowerCase() &&
+                                r.LastName.trim().toLowerCase() === client.LastName.trim().toLowerCase() &&
+                                (typeof r.DOB_DAY === 'string' ?
+                                    parseInt(r.DOB_DAY) : r.DOB_DAY) ===
+                                (typeof client.DOB_DAY === 'string' ?
+                                    parseInt(client.DOB_DAY) : client.DOB_DAY) &&
+                                (typeof r.DOB_MONTH === 'string' ?
+                                    parseInt(r.DOB_MONTH) : r.DOB_MONTH) ===
+                                (typeof client.DOB_MONTH === 'string' ?
+                                    parseInt(client.DOB_MONTH) : client.DOB_MONTH) &&
+                                (typeof r.DOB_YEAR === 'string' ?
+                                    parseInt(r.DOB_YEAR) : r.DOB_YEAR) ===
+                                (typeof client.DOB_YEAR === 'string' ?
+                                    parseInt(client.DOB_YEAR) : client.DOB_YEAR)
+                            )
+
+                            // Is user trying to add an existing active client?
+                            // If so then make the exiting client the active instead.
+                            if (existing) {
+                                handleOnSelected(existing);
+                                return;
+                            }
+                        }
+
+                        // Update or add the client
+                        setClient({
+                            action: "update",
+                            payload: client,
+                            cb: (c) => handleOnSelected(c as ResidentRecord)
+                        });
+                    }
+                }}
+            />
 
             {residentToDelete &&
             <Confirm.Modal

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -20,7 +20,7 @@ declare module 'reactn/default' {
         authManager: IAuthManager
         __client: {
             action: 'load' | 'update' | 'delete'
-            cb?: (c: ResidentRecord) => void
+            cb?: (c: ResidentRecord | ResidentRecord[] | undefined) => void
             payload: null | ResidentRecord | number
         } | null
         count: number

--- a/src/managers/MedicineManager.ts
+++ b/src/managers/MedicineManager.ts
@@ -129,12 +129,7 @@ const MedicineMananger = (
         if (!drugData.Id) {
             drugData.Id = null;
         }
-        if (drugData.Notes === '') {
-            drugData.Notes = null;
-        }
-        if (drugInfo.Directions === '') {
-            drugData.Directions = null;
-        }
+
         try {
             return await medicineProvider
             .post(drugData);

--- a/src/managers/ResidentManager.ts
+++ b/src/managers/ResidentManager.ts
@@ -15,6 +15,7 @@ const ResidentManager = (residentProvider: IResidentProvider): IResidentManager 
     /**
      * Inserts or updates a Resident record.
      * @param {ResidentRecord} residentRecord
+     * @todo Move dupe logic to back-end
      */
     const _updateResident = async (residentRecord: ResidentRecord): Promise<ResidentRecord> => {
         const residentData = {...residentRecord};

--- a/src/types/RecordTypes.ts
+++ b/src/types/RecordTypes.ts
@@ -25,15 +25,6 @@ export type DrugLogRecord = {
     [key: string]: any
 };
 
-export const newDrugLogRecord = {
-    Id: null,
-    MedicineId: 0,
-    Notes: "",
-    In: null,
-    Out: null,
-    ResidentId: 0
-} as DrugLogRecord;
-
 export type MedicineRecord = {
     Barcode: string | null
     Directions: string | null
@@ -58,3 +49,22 @@ export const newDrugInfo = {
     ResidentId: null,
     Strength: ''
 } as MedicineRecord;
+
+export const newDrugLogRecord = {
+    Id: null,
+    MedicineId: 0,
+    Notes: "",
+    In: null,
+    Out: null,
+    ResidentId: 0
+} as DrugLogRecord;
+
+export const newResidentRecord = {
+    Id: null,
+    FirstName: "",
+    LastName: "",
+    DOB_YEAR: "",
+    DOB_MONTH: "",
+    DOB_DAY: "",
+    Notes: ""
+} as ResidentRecord


### PR DESCRIPTION
- No longer use `residentInfo` in the ResidentPage.tsx instead use `showResidentEdit`
- Revamped 👷 how new clients are updated and added.
  - Logic to handle reactivation of existing clients has been moved completely to the back-end.
  - Added a `newResidentRecord` constant to be more consistent with how new records are created.
  - When adding new client the list of active clients is searched and if a match is found make that active.
  - If adding a new client and they exist as a deactivated client they are re-activated via backend logic now.
- Removed unneeded nullification of `Medicine.Notes` and `Medicine.Directions` that are handled on the backend now.
- ResidentManager.ts was greatly simplified.
- ClientObserver.ts was made to be much more promise based so serialization is better handled.
- The `__client` observer allows for more types in the callback property.
  