### PR TITLE
Revamp 💄 👷 OTC ListGroup

### DIFF
--- a/src/components/Pages/ListGroups/MedicineListGroup.tsx
+++ b/src/components/Pages/ListGroups/MedicineListGroup.tsx
@@ -1,12 +1,12 @@
-import React, {useEffect, useState} from 'reactn';
-import ListGroup from "react-bootstrap/ListGroup";
 import DrugDropdown from "./DrugDropdown";
-import TooltipButton from "../../Buttons/TooltipButton";
-import {drawBarcode} from "../../../utility/drawBarcode";
-import {MedicineRecord} from "../../../types/RecordTypes";
-import {getLastTakenVariant} from "../../../utility/common";
-import ShadowBox from "../../Buttons/ShadowBox";
+import ListGroup from "react-bootstrap/ListGroup";
 import LogButtons from "../../Buttons/LogButtons";
+import React, {useEffect} from 'reactn';
+import ShadowBox from "../../Buttons/ShadowBox";
+import TooltipButton from "../../Buttons/TooltipButton";
+import {MedicineRecord} from "../../../types/RecordTypes";
+import {drawBarcode} from "../../../utility/drawBarcode";
+import {getLastTakenVariant} from "../../../utility/common";
 
 interface IProps {
     activeDrug: MedicineRecord
@@ -49,7 +49,6 @@ const MedicineListGroup = (props: IProps): JSX.Element => {
     const fillDateType = (fillDateText) ? new Date(fillDateText) : null;
     const fillDateOptions = {month: '2-digit', day: '2-digit', year: 'numeric'} as Intl.DateTimeFormatOptions;
     const fillDate = (fillDateType) ? fillDateType.toLocaleString('en-US', fillDateOptions) : null;
-    const [showDetails, setShowDetails] = useState(false);
 
     // Update the barcode image if the barcode has changed
     useEffect(() => {
@@ -58,12 +57,7 @@ const MedicineListGroup = (props: IProps): JSX.Element => {
         if (canvasUpdated && canvas) {
             canvasUpdated(canvas);
         }
-    }, [barCode, canvasId, canvasUpdated, showDetails]);
-
-    // If the drugId changes then hide the details
-    useEffect(() => {
-        setShowDetails(false);
-    }, [drugId])
+    }, [barCode, canvasId, canvasUpdated]);
 
     /**
      * Determine the tooltip text given the number of hours the drug was last taken
@@ -126,39 +120,34 @@ const MedicineListGroup = (props: IProps): JSX.Element => {
                 />
             </ListGroup.Item>
 
-            <ListGroup.Item action onClick={() => setShowDetails(!showDetails)}>
-                {showDetails ? "Hide Details" : "Show Details"}
+            {directions && directions.length > 0 &&
+            <ListGroup.Item>
+                <ShadowBox>
+                    <b>Directions: </b>{activeDrug.Directions}
+                </ShadowBox>
             </ListGroup.Item>
+            }
 
-            {showDetails &&
-            <>
-                {directions && directions.length > 0 &&
-                <ListGroup.Item>
-                    <ShadowBox>
-                        <b>Directions: </b>{activeDrug.Directions}
-                    </ShadowBox>
-                </ListGroup.Item>
-                }
-                {notes && notes.length > 0 &&
-                <ListGroup.Item>
-                    <ShadowBox>
-                        <b>Notes: </b>{activeDrug.Notes}
-                    </ShadowBox>
-                </ListGroup.Item>
-                }
-                {fillDate &&
-                <ListGroup.Item>
-                    <ShadowBox>
-                        <b>Fill Date: </b>{fillDate}
-                    </ShadowBox>
-                </ListGroup.Item>
-                }
-                {barCode &&
-                <ListGroup.Item>
-                    <canvas id={canvasId}/>
-                </ListGroup.Item>
-                }
-            </>
+            {notes && notes.length > 0 &&
+            <ListGroup.Item>
+                <ShadowBox>
+                    <b>Notes: </b>{activeDrug.Notes}
+                </ShadowBox>
+            </ListGroup.Item>
+            }
+
+            {fillDate &&
+            <ListGroup.Item>
+                <ShadowBox>
+                    <b>Fill Date: </b>{fillDate}
+                </ShadowBox>
+            </ListGroup.Item>
+            }
+
+            {barCode &&
+            <ListGroup.Item>
+                <canvas id={canvasId}/>
+            </ListGroup.Item>
             }
         </ListGroup>
     );

--- a/src/components/Pages/ListGroups/OtcListGroup.tsx
+++ b/src/components/Pages/ListGroups/OtcListGroup.tsx
@@ -17,6 +17,7 @@ interface IProps {
     logOtcDrugAmount: (n: number) => void
     otcList: MedicineRecord[]
     setActiveOtcDrug: (d: MedicineRecord) => void
+    onDisplay?: (s: boolean) => void
 }
 
 /**
@@ -31,6 +32,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
         editOtcMedicine,
         logOtcDrug,
         logOtcDrugAmount,
+        onDisplay,
         otcList,
         setActiveOtcDrug
     } = props;
@@ -65,6 +67,13 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
             setFilteredOtcList(otcList);
         }
     }, [otcList, searchText])
+
+    // Invoke callback when the OtcListGroup is shown or hidden
+    useEffect(() => {
+        if (onDisplay) {
+            onDisplay(showOtc);
+        }
+    }, [showOtc, onDisplay])
 
     return (
         <ListGroup>
@@ -161,7 +170,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
 
             <Collapse in={showOtc}>
                 <ListGroup.Item>
-                    <div style={{height: "300px", overflow: "auto"}}>
+                    <div style={{height: "450px", overflow: "auto"}}>
                         <Table
                             bordered
                             hover

--- a/src/components/Pages/ListGroups/OtcListGroup.tsx
+++ b/src/components/Pages/ListGroups/OtcListGroup.tsx
@@ -82,7 +82,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                 as="button"
                 active={!showOtc}
                 onClick={() => setShowOtc(!showOtc)}
-                style={{height: "35px", verticalAlign: "middle", lineHeight: "100%"}}
+                style={{height: "35px", verticalAlign: "middle", lineHeight: "100%", zIndex: 0}}
             >
                 <div style={{textAlign: "center"}}>
                     {showOtc ? 'Hide OTC' : 'Show OTC'}

--- a/src/components/Pages/ListGroups/OtcListGroup.tsx
+++ b/src/components/Pages/ListGroups/OtcListGroup.tsx
@@ -3,7 +3,7 @@ import MedicineDetail from "../Grids/MedicineDetail";
 import React, {useEffect, useState} from "reactn";
 import ShadowBox from "../../Buttons/ShadowBox";
 import Table from "react-bootstrap/Table";
-import {Button, Form, FormGroup, InputGroup, ListGroup, ListGroupItem} from "react-bootstrap";
+import {Button, Collapse, Form, FormGroup, InputGroup, ListGroup, ListGroupItem} from "react-bootstrap";
 import {DrugLogRecord, MedicineRecord} from "../../../types/RecordTypes";
 import {calculateLastTaken, getLastTakenVariant} from "../../../utility/common";
 import {useRef} from "react";
@@ -66,15 +66,6 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
         }
     }, [otcList, searchText])
 
-    // Set focus to the search textbox when showOtc becomes true
-    useEffect(() => {
-        if (showOtc) {
-            searchRef?.current?.focus();
-        }  else {
-            setSearchText('');
-        }
-    }, [searchRef, showOtc])
-
     return (
         <ListGroup>
             <ListGroupItem
@@ -82,14 +73,17 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                 as="button"
                 active={!showOtc}
                 onClick={() => setShowOtc(!showOtc)}
+                style={{height: "35px", verticalAlign: "middle", lineHeight: "100%"}}
             >
                 <div style={{textAlign: "center"}}>
                     {showOtc ? 'Hide OTC' : 'Show OTC'}
                 </div>
             </ListGroupItem>
 
-            {showOtc &&
-            <>
+            <Collapse
+                in={showOtc}
+                onEntered={() => searchRef?.current?.focus()}
+            >
                 <ListGroup.Item>
                     <FormGroup>
                         <InputGroup>
@@ -163,7 +157,9 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                     </ShadowBox>
                     }
                 </ListGroup.Item>
+            </Collapse>
 
+            <Collapse in={showOtc}>
                 <ListGroup.Item>
                     <div style={{height: "300px", overflow: "auto"}}>
                         <Table
@@ -202,8 +198,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                         </Table>
                     </div>
                 </ListGroup.Item>
-            </>
-            }
+            </Collapse>
         </ListGroup>
     )
 }

--- a/src/components/Pages/ListGroups/OtcListGroup.tsx
+++ b/src/components/Pages/ListGroups/OtcListGroup.tsx
@@ -13,7 +13,7 @@ interface IProps {
     addOtcMedicine: () => void
     drugLogList: DrugLogRecord[]
     editOtcMedicine: () => void
-    logOtcDrug: () => void
+    logOtcDrug: (e: React.MouseEvent<HTMLElement>) => void
     logOtcDrugAmount: (n: number) => void
     otcList: MedicineRecord[]
     setActiveOtcDrug: (d: MedicineRecord) => void
@@ -145,7 +145,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                     </FormGroup>
                     <FormGroup>
                         <Button
-                            onClick={() => logOtcDrug()}
+                            onClick={(e) => logOtcDrug(e)}
                             className="mr-2"
                             size="sm"
                             variant={lastTakenVariant}

--- a/src/components/Pages/ListGroups/OtcListGroup.tsx
+++ b/src/components/Pages/ListGroups/OtcListGroup.tsx
@@ -1,20 +1,22 @@
-import {Button, Form, FormGroup, InputGroup, ListGroup} from "react-bootstrap";
-import Table from "react-bootstrap/Table";
-import {DrugLogRecord, MedicineRecord} from "../../../types/RecordTypes";
+import LogButtons from "../../Buttons/LogButtons";
 import MedicineDetail from "../Grids/MedicineDetail";
 import React, {useEffect, useState} from "reactn";
-import LogButtons from "../../Buttons/LogButtons";
-import {calculateLastTaken, getLastTakenVariant} from "../../../utility/common";
 import ShadowBox from "../../Buttons/ShadowBox";
+import Table from "react-bootstrap/Table";
+import {Button, Form, FormGroup, InputGroup, ListGroup, ListGroupItem} from "react-bootstrap";
+import {DrugLogRecord, MedicineRecord} from "../../../types/RecordTypes";
+import {calculateLastTaken, getLastTakenVariant} from "../../../utility/common";
+import {useRef} from "react";
 
 interface IProps {
     activeOtcDrug: MedicineRecord
-    addOtcMedicine: () => (void)
+    addOtcMedicine: () => void
     drugLogList: DrugLogRecord[]
-    editOtcMedicine: () => (void)
-    logOtcDrugAmount: (n: number) => (void)
+    editOtcMedicine: () => void
+    logOtcDrug: () => void
+    logOtcDrugAmount: (n: number) => void
     otcList: MedicineRecord[]
-    setActiveOtcDrug: (d: MedicineRecord) => (void)
+    setActiveOtcDrug: (d: MedicineRecord) => void
 }
 
 /**
@@ -27,6 +29,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
         addOtcMedicine,
         drugLogList,
         editOtcMedicine,
+        logOtcDrug,
         logOtcDrugAmount,
         otcList,
         setActiveOtcDrug
@@ -37,6 +40,8 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
     const [searchIsValid, setSearchIsValid] = useState<boolean | null>(null);
     const [searchText, setSearchText] = useState('');
     const [filteredOtcList, setFilteredOtcList] = useState(otcList);
+    const [showOtc, setShowOtc] = useState(false);
+    const searchRef = useRef<HTMLInputElement>(null);
 
     // Filter the otcList by the search textbox value
     useEffect(() => {
@@ -61,118 +66,144 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
         }
     }, [otcList, searchText])
 
+    // Set focus to the search textbox when showOtc becomes true
+    useEffect(() => {
+        if (showOtc) {
+            searchRef?.current?.focus();
+        }  else {
+            setSearchText('');
+        }
+    }, [searchRef, showOtc])
+
     return (
         <ListGroup>
-            <ListGroup.Item>
-                <FormGroup>
-                    <InputGroup>
-                        <InputGroup.Prepend>
-                            <Form.Control
-                                className="mr-2"
-                                id="otc-page-search-text"
-                                isValid={searchIsValid || false}
-                                placeholder="Search OTC medicine"
-                                size="sm"
-                                style={{width: "220px"}}
-                                type="search"
-                                value={searchText}
-                                onChange={(e) => setSearchText(e.target.value)}
-                                onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
-                                    if (e.key === 'Enter') {
-                                        e.preventDefault();
-                                    }
-                                }}
-                            />
-                        </InputGroup.Prepend>
-                        <InputGroup.Append style={{zIndex: 0}}>
-                            <Button
-                                className="mr-1"
-                                size="sm"
-                                variant="info"
-                                onClick={(e) => {
-                                    e.preventDefault();
-                                    addOtcMedicine();
-                                }}
-                            >
-                                + OTC
-                            </Button>
-
-                            {activeOtcDrug &&
-                            <Button
-                                size="sm"
-                                variant="info"
-                                onClick={(e) => {
-                                    e.preventDefault();
-                                    editOtcMedicine();
-                                }}
-                            >
-                                Edit <b>{activeOtcDrug.Drug}</b>
-                            </Button>
-                            }
-                        </InputGroup.Append>
-                    </InputGroup>
-                </FormGroup>
-                <FormGroup>
-                    <Button
-                        className="mr-2"
-                        size="sm"
-                        variant={lastTakenVariant}
-                    >
-                        + Log OTC
-                    </Button>
-
-                    <LogButtons
-                        drugName={activeOtcDrug.Drug}
-                        lastTaken={lastTaken}
-                        lastTakenVariant={lastTakenVariant}
-                        onLogAmount={(n) => logOtcDrugAmount(n)}
-                    />
-                </FormGroup>
-                {activeOtcDrug.Directions &&
-                <ShadowBox>
-                    <span><b>Directions: </b> {activeOtcDrug.Directions}</span>
-                </ShadowBox>
-                }
-            </ListGroup.Item>
-
-            <ListGroup.Item>
-                <div style={{height: "300px", overflow: "auto"}}>
-                    <Table
-                        bordered
-                        hover
-                        size="sm"
-                        striped
-                    >
-                        <thead>
-                        <tr>
-                            <th/>
-                            <th>
-                                Drug
-                            </th>
-                            <th>
-                                Strength
-                            </th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {filteredOtcList.map((drug: MedicineRecord) =>
-                            <MedicineDetail
-                                activeDrug={activeOtcDrug}
-                                columns={[
-                                    'Drug',
-                                    'Strength'
-                                ]}
-                                drug={drug}
-                                key={'otc' + drug.Id}
-                                onSelect={(e, d) => {
-                                    setActiveOtcDrug(d);
-                                }}
-                            />)
-                        }
-                        </tbody>
-                    </Table>
+            <ListGroupItem
+                action
+                as="button"
+                active={!showOtc}
+                onClick={() => setShowOtc(!showOtc)}
+            >
+                <div style={{textAlign: "center"}}>
+                    {showOtc ? 'Hide OTC' : 'Show OTC'}
                 </div>
-            </ListGroup.Item>
+            </ListGroupItem>
+
+            {showOtc &&
+            <>
+                <ListGroup.Item>
+                    <FormGroup>
+                        <InputGroup>
+                            <InputGroup.Prepend>
+                                <Form.Control
+                                    className="mr-2"
+                                    id="otc-page-search-text"
+                                    isValid={searchIsValid || false}
+                                    placeholder="Search OTC medicine"
+                                    size="sm"
+                                    style={{width: "220px"}}
+                                    type="search"
+                                    ref={searchRef}
+                                    value={searchText}
+                                    onChange={(e) => setSearchText(e.target.value)}
+                                    onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
+                                        if (e.key === 'Enter') {
+                                            e.preventDefault();
+                                        }
+                                    }}
+                                />
+                            </InputGroup.Prepend>
+                            <InputGroup.Append style={{zIndex: 0}}>
+                                <Button
+                                    className="mr-1"
+                                    size="sm"
+                                    variant="info"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        addOtcMedicine();
+                                    }}
+                                >
+                                    + OTC
+                                </Button>
+
+                                {activeOtcDrug &&
+                                <Button
+                                    size="sm"
+                                    variant="info"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        editOtcMedicine();
+                                    }}
+                                >
+                                    Edit <b>{activeOtcDrug.Drug}</b>
+                                </Button>
+                                }
+                            </InputGroup.Append>
+                        </InputGroup>
+                    </FormGroup>
+                    <FormGroup>
+                        <Button
+                            onClick={() => logOtcDrug()}
+                            className="mr-2"
+                            size="sm"
+                            variant={lastTakenVariant}
+                        >
+                            + Log OTC
+                        </Button>
+
+                        <LogButtons
+                            drugName={activeOtcDrug.Drug}
+                            lastTaken={lastTaken}
+                            lastTakenVariant={lastTakenVariant}
+                            onLogAmount={(n) => logOtcDrugAmount(n)}
+                        />
+                    </FormGroup>
+                    {activeOtcDrug.Directions &&
+                    <ShadowBox>
+                        <span><b>Directions: </b> {activeOtcDrug.Directions}</span>
+                    </ShadowBox>
+                    }
+                </ListGroup.Item>
+
+                <ListGroup.Item>
+                    <div style={{height: "300px", overflow: "auto"}}>
+                        <Table
+                            bordered
+                            hover
+                            size="sm"
+                            striped
+                        >
+                            <thead>
+                            <tr>
+                                <th/>
+                                <th>
+                                    Drug
+                                </th>
+                                <th>
+                                    Strength
+                                </th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {filteredOtcList.map((drug: MedicineRecord) =>
+                                <MedicineDetail
+                                    activeDrug={activeOtcDrug}
+                                    columns={[
+                                        'Drug',
+                                        'Strength'
+                                    ]}
+                                    drug={drug}
+                                    key={'otc' + drug.Id}
+                                    onSelect={(e, d) => {
+                                        setActiveOtcDrug(d);
+                                    }}
+                                />)
+                            }
+                            </tbody>
+                        </Table>
+                    </div>
+                </ListGroup.Item>
+            </>
+            }
         </ListGroup>
     )
 }

--- a/src/components/Pages/MedicinePage.tsx
+++ b/src/components/Pages/MedicinePage.tsx
@@ -119,6 +119,7 @@ const MedicinePage = (): JSX.Element | null => {
      * Fires when user clicks on +Log or the drug log edit button
      * @param {React.MouseEvent<HTMLElement>} e
      * @param {DrugLogRecord} drugLogInfo
+     * @todo Fix this for OTC drugs as well
      */
     const addEditDrugLog = (e: React.MouseEvent<HTMLElement>, drugLogInfo?: DrugLogRecord) => {
         e.preventDefault();
@@ -248,6 +249,10 @@ const MedicinePage = (): JSX.Element | null => {
                             activeOtcDrug={activeOtcDrug}
                             drugLogList={drugLogList}
                             logOtcDrugAmount={(n) => handleLogOtcDrugAmount(n)}
+                            logOtcDrug={() => {
+                                // TODO: Show EditDrug modal for the OTC drug
+                                alert('not implemented');
+                            }}
                             otcList={otcList}
                             setActiveOtcDrug={(d) => setActiveOtcDrug(d)}/>
                     </Row>

--- a/src/components/Pages/MedicinePage.tsx
+++ b/src/components/Pages/MedicinePage.tsx
@@ -111,18 +111,30 @@ const MedicinePage = (): JSX.Element | null => {
 
     /**
      * Fires when user clicks on +Log or the drug log edit button
-     * @param {React.MouseEvent<HTMLElement>} e
      * @param {DrugLogRecord} drugLogInfo
-     * @todo Fix this for OTC drugs as well
      */
-    const addEditDrugLog = (e: React.MouseEvent<HTMLElement>, drugLogInfo?: DrugLogRecord) => {
-        e.preventDefault();
+    const addEditDrugLog = (drugLogInfo?: DrugLogRecord) => {
         const drugLogRecord = drugLogInfo ? {...drugLogInfo} : {
             Id: null,
             ResidentId: residentId,
             MedicineId: activeDrug?.Id,
             Notes: ""
         } as DrugLogRecord;
+        setShowDrugLog(drugLogRecord);
+    }
+
+    /**
+     * Fires when user clicks on +Log or the drug log edit button for OTC drugs
+     * @param {DrugLogRecord} drugLogInfo
+     */
+    const addEditOtcLog = (drugLogInfo?: DrugLogRecord) => {
+        const drugLogRecord = drugLogInfo ? {...drugLogInfo} : {
+            Id: null,
+            ResidentId: residentId,
+            MedicineId: activeOtcDrug?.Id,
+            Notes: ""
+        } as DrugLogRecord;
+        console.log('OTC drugLogRecord', drugLogRecord);
         setShowDrugLog(drugLogRecord);
     }
 
@@ -145,7 +157,7 @@ const MedicinePage = (): JSX.Element | null => {
     }
 
     /**
-     * Fires when the Log 1 or Log 2, etc. buttons are clicked in the OtcListGroup are clicked
+     * Fires when the Log 1 or Log 2, etc. buttons are clicked for OTC drugs
      * @param {number} amount
      */
     const handleLogOtcDrugAmount = (amount: number) => {
@@ -222,7 +234,10 @@ const MedicinePage = (): JSX.Element | null => {
                     <Row className="mt-3">
                         <MedicineListGroup
                             activeDrug={activeDrug}
-                            addDrugLog={(e: React.MouseEvent<HTMLElement>) => addEditDrugLog(e)}
+                            addDrugLog={(e: React.MouseEvent<HTMLElement>) => {
+                                e.preventDefault();
+                                addEditDrugLog();
+                            }}
                             canvasId={'med-barcode'}
                             disabled={drugLog !== null}
                             drugChanged={(drug: MedicineRecord) => setActiveDrug(drug)}
@@ -245,13 +260,13 @@ const MedicinePage = (): JSX.Element | null => {
                             activeOtcDrug={activeOtcDrug}
                             drugLogList={drugLogList}
                             logOtcDrugAmount={(n) => handleLogOtcDrugAmount(n)}
-                            logOtcDrug={() => {
-                                // TODO: Show EditDrug modal for the OTC drug
-                                alert('not implemented');
+                            logOtcDrug={(e) => {
+                                e.preventDefault();
+                                addEditOtcLog();
                             }}
                             otcList={otcList}
                             setActiveOtcDrug={(d) => setActiveOtcDrug(d)}
-                            onDisplay={(d)=>setOtcGroupShown(d)}
+                            onDisplay={(d) => setOtcGroupShown(d)}
                         />
                     </Row>
                     }
@@ -278,7 +293,10 @@ const MedicinePage = (): JSX.Element | null => {
                             drugLog={drugLogList}
                             drugId={activeDrug && activeDrug.Id}
                             columns={['Created', 'Updated', 'Notes', 'Out', 'In']}
-                            onEdit={(e, r) => addEditDrugLog(e, r)}
+                            onEdit={(e, r) => {
+                                e.preventDefault();
+                                addEditDrugLog(r);
+                            }}
                             onDelete={(e, r) => setShowDeleteDrugLogRecord(r)}
                         />
                     </ListGroup.Item>
@@ -291,7 +309,10 @@ const MedicinePage = (): JSX.Element | null => {
                             drugLog={otcLogList}
                             medicineList={otcList}
                             columns={['Drug', 'Created', 'Updated', 'Notes']}
-                            onEdit={(e, r) => addEditDrugLog(e, r)}
+                            onEdit={(e, r) => {
+                                e.preventDefault();
+                                addEditOtcLog(r);
+                            }}
                             onDelete={(e, r) => setShowDeleteDrugLogRecord(r)}
                         />
                     </ListGroup.Item>
@@ -320,7 +341,7 @@ const MedicinePage = (): JSX.Element | null => {
 
             {showDrugLog &&
             <DrugLogEdit
-                drugName={getDrugName(activeDrug && activeDrug.Id ? activeDrug.Id : 0, medicineList)}
+                drugName={getDrugName(showDrugLog.MedicineId, medicineList.concat(otcList))}
                 show={true}
                 drugLogInfo={showDrugLog}
                 onHide={() => setShowDrugLog(null)}

--- a/src/components/Pages/MedicinePage.tsx
+++ b/src/components/Pages/MedicinePage.tsx
@@ -37,6 +37,7 @@ const MedicinePage = (): JSX.Element | null => {
     const [medicineList] = useGlobal('medicineList');
     const [otcList] = useGlobal('otcList');
     const [otcLogList, setOtcLogList] = useState<DrugLogRecord[]>([]);
+    const [otcGroupShown, setOtcGroupShown] = useState<boolean>(false);
     const [residentId, setResidentId] = useState<number | null>(activeResident?.Id || null);
     const [showDeleteDrugLogRecord, setShowDeleteDrugLogRecord] = useState<DrugLogRecord | null>(null);
     const [showDrugLog, setShowDrugLog] = useState<DrugLogRecord | null>(null);
@@ -174,6 +175,7 @@ const MedicinePage = (): JSX.Element | null => {
         <>
             <Form className={TabContent} as={Row}>
                 <Col lg="4">
+                    {!otcGroupShown &&
                     <Row>
                         <TooltipButton
                             className="mr-1"
@@ -221,9 +223,10 @@ const MedicinePage = (): JSX.Element | null => {
                             Print Medicine Checkout
                         </Button>
                     </Row>
+                    }
 
+                    {!otcGroupShown && activeDrug &&
                     <Row className="mt-3">
-                        {activeDrug &&
                         <MedicineListGroup
                             activeDrug={activeDrug}
                             addDrugLog={(e: React.MouseEvent<HTMLElement>) => addEditDrugLog(e)}
@@ -234,11 +237,11 @@ const MedicinePage = (): JSX.Element | null => {
                             logDrug={(amount: number) => handleLogDrugAmount(amount, activeDrug.Id as number)}
                             medicineList={medicineList}
                         />
-                        }
                     </Row>
+                    }
 
                     {activeOtcDrug &&
-                    <Row className="mt-4">
+                    <Row className={otcGroupShown ? "" : "mt-4"}>
                         <OtcListGroup
                             addOtcMedicine={() => {
                                 setShowMedicineEdit({...newDrugInfo, OTC: true});
@@ -254,7 +257,9 @@ const MedicinePage = (): JSX.Element | null => {
                                 alert('not implemented');
                             }}
                             otcList={otcList}
-                            setActiveOtcDrug={(d) => setActiveOtcDrug(d)}/>
+                            setActiveOtcDrug={(d) => setActiveOtcDrug(d)}
+                            onDisplay={(d)=>setOtcGroupShown(d)}
+                        />
                     </Row>
                     }
                 </Col>

--- a/src/components/Pages/MedicinePage.tsx
+++ b/src/components/Pages/MedicinePage.tsx
@@ -7,14 +7,14 @@ import Form from 'react-bootstrap/Form';
 import LastTakenButton from "../Buttons/LastTakenButton";
 import MedicineEdit from "./Modals/MedicineEdit";
 import MedicineListGroup from "./ListGroups/MedicineListGroup";
-import React, {useEffect, useGlobal, useRef, useState} from 'reactn';
+import OtcListGroup from "./ListGroups/OtcListGroup";
+import React, {useEffect, useGlobal, useState} from 'reactn';
 import Row from 'react-bootstrap/Row';
 import TabContent from "../../styles/common.css";
 import TooltipButton from "../Buttons/TooltipButton";
 import {Alert, ListGroup} from "react-bootstrap";
 import {DrugLogRecord, MedicineRecord, newDrugInfo} from "../../types/RecordTypes";
 import {calculateLastTaken, getCheckoutList, getDrugName, getFormattedDate, getMDY} from "../../utility/common";
-import OtcListGroup from "./ListGroups/OtcListGroup";
 
 /**
  * MedicinePage
@@ -35,14 +35,13 @@ const MedicinePage = (): JSX.Element | null => {
     const [gridHeight, setGridHeight] = useState('675px');
     const [lastTaken, setLastTaken] = useState<number | null>(null);
     const [medicineList] = useGlobal('medicineList');
+    const [otcGroupShown, setOtcGroupShown] = useState<boolean>(false);
     const [otcList] = useGlobal('otcList');
     const [otcLogList, setOtcLogList] = useState<DrugLogRecord[]>([]);
-    const [otcGroupShown, setOtcGroupShown] = useState<boolean>(false);
     const [residentId, setResidentId] = useState<number | null>(activeResident?.Id || null);
     const [showDeleteDrugLogRecord, setShowDeleteDrugLogRecord] = useState<DrugLogRecord | null>(null);
     const [showDrugLog, setShowDrugLog] = useState<DrugLogRecord | null>(null);
     const [showMedicineEdit, setShowMedicineEdit] = useState<MedicineRecord | null>(null);
-    const focusRef = useRef<HTMLInputElement>(null);
 
     // Set the activeDrug when the medicineList changes
     useEffect(() => {
@@ -62,21 +61,15 @@ const MedicinePage = (): JSX.Element | null => {
         }
     }, [activeDrug, drugLogList]);
 
-    // Set focus to the search input if the page key has changed
-    useEffect(() => {
-        if (activeTabKey === 'medicine' && focusRef && focusRef.current) {
-            focusRef.current.focus();
-        }
-    }, [activeTabKey]);
-
     // Set the local clientId state
     useEffect(() => {
         const clientId = activeResident?.Id ? activeResident.Id : null;
         setResidentId(clientId);
     }, [activeResident]);
 
+    // Disable or Enable Print Checkout button based on if there are any drugs marked as to be checked out
     useEffect(() => {
-        if (apiKey && activeResident && drugLogList.length > 0) {
+        if (drugLogList?.length > 0) {
             const checkoutList = getCheckoutList(drugLogList);
             if (checkoutList.length > 0) {
                 setCheckoutDisabled(false);
@@ -86,7 +79,7 @@ const MedicinePage = (): JSX.Element | null => {
         } else {
             setCheckoutDisabled(true);
         }
-    }, [activeResident, apiKey, drugLogList])
+    }, [drugLogList])
 
     // Set the activeOtcDrug when the otcList changes.
     useEffect(() => {

--- a/src/components/Pages/ResidentPage.tsx
+++ b/src/components/Pages/ResidentPage.tsx
@@ -27,9 +27,9 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
     const [residentToDelete, setResidentToDelete] = useState<ResidentRecord | null>(null);
     const [searchIsValid, setSearchIsValid] = useState(false);
     const [searchText, setSearchText] = useState('');
+    const [showClientRoster, setShowClientRoster] = useState(false);
     const [showDeleteResident, setShowDeleteResident] = useState(false);
     const [showResidentEdit, setShowResidentEdit] = useState<ResidentRecord | null>(null);
-    const [showClientRoster, setShowClientRoster] = useState(false);
     const focusRef = useRef<HTMLInputElement>(null);
     const onSelected = props.residentSelected;
 
@@ -44,8 +44,8 @@ const ResidentPage = (props: IProps): JSX.Element | null => {
     useEffect(() => {
         if (searchText.length > 0) {
             const filter = residentList.filter((residentRecord) => {
-                const lastName = residentRecord.LastName.toLowerCase();
                 const firstName = residentRecord.FirstName.toLowerCase();
+                const lastName = residentRecord.LastName.toLowerCase();
                 const search = searchText.toLowerCase();
                 return lastName.includes(search) || firstName.includes(search);
             })


### PR DESCRIPTION
- 💄 Add show/hide button to OtcListGroup.tsx
- Set focus to the OTC search textbox when shown
- 💄 Use `<Collapse>` component to show/hide the OTC details.
- 💄 Hide the RxListGroup when the OtcListGroup is shown.
- Add style `zIndex: 0` to OtcListGroup so that the Rx Show OTC button doesn't _bleed through_
- Remove an unneeded `useEffect()` that was trying to set focus to a non-existent textbox.
- Fixed a bug 🐛 when editing or adding an OTC drug the activeDrug would be in the modal title.