### PR TITLE
Add spinner :ferris_wheel:  to indicate when system is busy

### DIFF
--- a/src/components/Pages/ListGroups/DisabledSpinner.tsx
+++ b/src/components/Pages/ListGroups/DisabledSpinner.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import {Spinner, SpinnerProps} from "react-bootstrap";
+
+// @ts-ignore Allow the animation prop to be optional as we default it to "border" by default
+interface IProps extends SpinnerProps {
+    animation?: 'border' | 'grow'
+}
+
+/**
+ * Spinner to be shown when in a disabled state with an optional components to the right (typically a button)
+ * @param {React.PropsWithChildren<IProps>} props
+ */
+const DisabledSpinner = (props: IProps) => {
+    const {
+        animation="border",
+        children,
+        size="sm",
+        as="span",
+        role="status"
+    } = {...props}
+
+    return (
+        <>
+            <Spinner
+                {...props}
+                animation={animation}
+                size={size}
+                as={as}
+                role={role}
+                aria-hidden="true"
+            >
+                {false && children}
+            </Spinner> { } {children}
+        </>
+    )
+}
+
+export default DisabledSpinner;

--- a/src/components/Pages/ListGroups/DrugDropdown.tsx
+++ b/src/components/Pages/ListGroups/DrugDropdown.tsx
@@ -2,9 +2,9 @@ import React from 'reactn';
 
 import Dropdown from "react-bootstrap/Dropdown";
 import DropdownButton from "react-bootstrap/DropdownButton";
-import {Spinner} from "react-bootstrap";
 
 import {MedicineRecord} from "../../../types/RecordTypes";
+import DisabledSpinner from "./DisabledSpinner";
 
 interface IProps {
     disabled?: boolean
@@ -77,24 +77,6 @@ const DrugDropdown = (props: IProps): JSX.Element | null => {
     };
 
     /**
-     * Spinner to be shown when dropdown is disabled with an optional component to the right
-     * @param {React.ReactNode} title
-     */
-    const disabledSpinner = (title?: React.ReactNode) => {
-        return (
-            <>
-                <Spinner
-                    animation="grow"
-                    size="sm"
-                    as="span"
-                    role="status"
-                    aria-hidden="true"
-                /> { } {title}
-            </>
-        )
-    }
-
-    /**
      * Work-around so React 17 can be used
      * @link https://github.com/react-bootstrap/react-bootstrap/issues/5409#issuecomment-718699584
      */
@@ -103,7 +85,7 @@ const DrugDropdown = (props: IProps): JSX.Element | null => {
             disabled={disabled}
             onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
             size="sm"
-            title={disabled ? disabledSpinner(title) : title}
+            title={disabled ? <DisabledSpinner>{title}</DisabledSpinner> : title}
             variant="primary"
         >
             {medicineList.map(MedicineDropdownItems)}

--- a/src/components/Pages/ListGroups/OtcListGroup.tsx
+++ b/src/components/Pages/ListGroups/OtcListGroup.tsx
@@ -1,23 +1,26 @@
-import LogButtons from "../../Buttons/LogButtons";
-import MedicineDetail from "../Grids/MedicineDetail";
-import React, {useEffect, useState} from "reactn";
-import ShadowBox from "../../Buttons/ShadowBox";
+import React, {useEffect, useRef, useState} from "reactn";
+
 import Table from "react-bootstrap/Table";
 import {Button, Collapse, Form, FormGroup, InputGroup, ListGroup, ListGroupItem} from "react-bootstrap";
+
+import DisabledSpinner from "./DisabledSpinner";
+import LogButtons from "../../Buttons/LogButtons";
+import MedicineDetail from "../Grids/MedicineDetail";
+import ShadowBox from "../../Buttons/ShadowBox";
 import {DrugLogRecord, MedicineRecord} from "../../../types/RecordTypes";
 import {calculateLastTaken, getLastTakenVariant} from "../../../utility/common";
-import {useRef} from "react";
 
 interface IProps {
     activeOtcDrug: MedicineRecord
     addOtcMedicine: () => void
+    disabled?: boolean
     drugLogList: DrugLogRecord[]
     editOtcMedicine: () => void
     logOtcDrug: (e: React.MouseEvent<HTMLElement>) => void
     logOtcDrugAmount: (n: number) => void
+    onDisplay?: (s: boolean) => void
     otcList: MedicineRecord[]
     setActiveOtcDrug: (d: MedicineRecord) => void
-    onDisplay?: (s: boolean) => void
 }
 
 /**
@@ -28,6 +31,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
     const {
         activeOtcDrug,
         addOtcMedicine,
+        disabled = false,
         drugLogList,
         editOtcMedicine,
         logOtcDrug,
@@ -37,12 +41,12 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
         setActiveOtcDrug
     } = props;
 
-    const lastTaken = (activeOtcDrug && activeOtcDrug.Id) ? calculateLastTaken(activeOtcDrug.Id, drugLogList) : null;
-    const lastTakenVariant = lastTaken && lastTaken >= 8 ? 'primary' : getLastTakenVariant(lastTaken);
+    const [filteredOtcList, setFilteredOtcList] = useState(otcList);
     const [searchIsValid, setSearchIsValid] = useState<boolean | null>(null);
     const [searchText, setSearchText] = useState('');
-    const [filteredOtcList, setFilteredOtcList] = useState(otcList);
     const [showOtc, setShowOtc] = useState(false);
+    const lastTaken = (activeOtcDrug && activeOtcDrug.Id) ? calculateLastTaken(activeOtcDrug.Id, drugLogList) : null;
+    const lastTakenVariant = lastTaken && lastTaken >= 8 ? 'primary' : getLastTakenVariant(lastTaken);
     const searchRef = useRef<HTMLInputElement>(null);
 
     // Filter the otcList by the search textbox value
@@ -79,13 +83,18 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
         <ListGroup>
             <ListGroupItem
                 action
-                as="button"
                 active={!showOtc}
+                as="button"
+                disabled={disabled}
                 onClick={() => setShowOtc(!showOtc)}
                 style={{height: "35px", verticalAlign: "middle", lineHeight: "100%", zIndex: 0}}
             >
                 <div style={{textAlign: "center"}}>
-                    {showOtc ? 'Hide OTC' : 'Show OTC'}
+                    {disabled ?
+                        (<DisabledSpinner>{showOtc ? 'Hide OTC' : 'Show OTC'}</DisabledSpinner>)
+                        :
+                        (<>{showOtc ? 'Hide OTC' : 'Show OTC'}</>)
+                    }
                 </div>
             </ListGroupItem>
 
@@ -93,7 +102,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                 in={showOtc}
                 onEntered={() => searchRef?.current?.focus()}
             >
-                <ListGroup.Item>
+                <ListGroup.Item disabled={disabled}>
                     <FormGroup>
                         <InputGroup>
                             <InputGroup.Prepend>
@@ -101,41 +110,41 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                                     className="mr-2"
                                     id="otc-page-search-text"
                                     isValid={searchIsValid || false}
-                                    placeholder="Search OTC medicine"
-                                    size="sm"
-                                    style={{width: "220px"}}
-                                    type="search"
-                                    ref={searchRef}
-                                    value={searchText}
                                     onChange={(e) => setSearchText(e.target.value)}
                                     onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
                                         if (e.key === 'Enter') {
                                             e.preventDefault();
                                         }
                                     }}
+                                    placeholder="Search OTC medicine"
+                                    ref={searchRef}
+                                    size="sm"
+                                    style={{width: "220px"}}
+                                    type="search"
+                                    value={searchText}
                                 />
                             </InputGroup.Prepend>
                             <InputGroup.Append style={{zIndex: 0}}>
                                 <Button
                                     className="mr-1"
-                                    size="sm"
-                                    variant="info"
                                     onClick={(e) => {
                                         e.preventDefault();
                                         addOtcMedicine();
                                     }}
+                                    size="sm"
+                                    variant="info"
                                 >
                                     + OTC
                                 </Button>
 
                                 {activeOtcDrug &&
                                 <Button
-                                    size="sm"
-                                    variant="info"
                                     onClick={(e) => {
                                         e.preventDefault();
                                         editOtcMedicine();
                                     }}
+                                    size="sm"
+                                    variant="info"
                                 >
                                     Edit <b>{activeOtcDrug.Drug}</b>
                                 </Button>
@@ -145,8 +154,8 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                     </FormGroup>
                     <FormGroup>
                         <Button
-                            onClick={(e) => logOtcDrug(e)}
                             className="mr-2"
+                            onClick={(e) => logOtcDrug(e)}
                             size="sm"
                             variant={lastTakenVariant}
                         >
@@ -169,7 +178,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
             </Collapse>
 
             <Collapse in={showOtc}>
-                <ListGroup.Item>
+                <ListGroup.Item disabled={disabled}>
                     <div style={{height: "450px", overflow: "auto"}}>
                         <Table
                             bordered

--- a/src/components/Pages/MedicinePage.tsx
+++ b/src/components/Pages/MedicinePage.tsx
@@ -1,18 +1,20 @@
+import React, {useEffect, useGlobal, useState} from 'reactn';
+
 import Button from 'react-bootstrap/Button';
 import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
+import {Alert, ListGroup} from "react-bootstrap";
+
 import Confirm from "./Modals/Confirm";
 import DrugLogEdit from "./Modals/DrugLogEdit";
 import DrugLogGrid from "./Grids/DrugLogGrid";
-import Form from 'react-bootstrap/Form';
 import LastTakenButton from "../Buttons/LastTakenButton";
 import MedicineEdit from "./Modals/MedicineEdit";
 import MedicineListGroup from "./ListGroups/MedicineListGroup";
 import OtcListGroup from "./ListGroups/OtcListGroup";
-import React, {useEffect, useGlobal, useState} from 'reactn';
-import Row from 'react-bootstrap/Row';
 import TabContent from "../../styles/common.css";
 import TooltipButton from "../Buttons/TooltipButton";
-import {Alert, ListGroup} from "react-bootstrap";
 import {DrugLogRecord, MedicineRecord, newDrugInfo} from "../../types/RecordTypes";
 import {calculateLastTaken, getCheckoutList, getDrugName, getFormattedDate, getMDY} from "../../utility/common";
 
@@ -43,6 +45,7 @@ const MedicinePage = (): JSX.Element | null => {
     const [showMedicineEdit, setShowMedicineEdit] = useState<MedicineRecord | null>(null);
 
     // Set the activeDrug when the medicineList changes
+    // Todo: Better handling of state here
     useEffect(() => {
         if (medicineList.length > 0) {
             setActiveDrug(medicineList[0]);
@@ -250,6 +253,7 @@ const MedicinePage = (): JSX.Element | null => {
                     {activeOtcDrug &&
                     <Row className={otcGroupShown ? "" : "mt-4"}>
                         <OtcListGroup
+                            disabled={drugLog !== null}
                             addOtcMedicine={() => {
                                 setShowMedicineEdit({...newDrugInfo, OTC: true});
                             }}
@@ -348,8 +352,6 @@ const MedicinePage = (): JSX.Element | null => {
                     setShowDrugLog(null);
                     if (drugLogRecord) {
                         setDrugLog({action: 'update', payload: drugLogRecord});
-                    } else {
-                        setDrugLog(null);
                     }
                 }}
             />
@@ -360,8 +362,10 @@ const MedicinePage = (): JSX.Element | null => {
             <Confirm.Modal
                 size='lg'
                 onSelect={(a) => {
-                    setDrugLog(a ? {action: 'delete', payload: showDeleteDrugLogRecord?.Id as number} : null);
                     setShowDeleteDrugLogRecord(null);
+                    if (a) {
+                        setDrugLog({action: 'delete', payload: showDeleteDrugLogRecord?.Id as number});
+                    }
                 }}
                 show={true}
                 buttonvariant="danger"


### PR DESCRIPTION
Customer facing 😀:
- When the system is busy some buttons and other components will be disabled and a spinner 🎡 will be displayed until the system is available again.

Internal 👽:
- Created a DisabledSpinner.tsx component.
- DrugDropdown.tsx and OtcListGroup.tsx utilize the DisabledSpinner.tsx component when `disabled={true}`
- Added a `disabled` attribute to OtcListGroup.tsx
- Import code clean-up and formatting [unrelated]