### PR TITLE
Revamp the client name and DOB buttons

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,11 +1,13 @@
 import React, {useGlobal, useState} from 'reactn';
 
-import {Popover, PopoverTitle} from "react-bootstrap";
+import {ButtonGroup} from "react-bootstrap";
 
 import About from "./Pages/Modals/About";
 import ActiveResidentObserver from "../observers/ActiveResidentObserver";
 import ApiKeyObserver from "../observers/ApiKeyObserver";
 import AuthObserver from "../observers/AuthObserver";
+import ClientButton from "./Buttons/ClientButton";
+import ClientDobButton from "./Buttons/ClientDobButton";
 import ClientObserver from "../observers/ClientObserver";
 import ClientRoster from "./Pages/Modals/ClientRoster";
 import DrugLogObserver from "../observers/DrugLogObserver";
@@ -13,11 +15,8 @@ import ErrorDetailsObserver from "../observers/ErrorDetailsObserver";
 import LandingPage from "./Pages/LandingPage";
 import MedicineObserver from "../observers/MedicineObserver";
 import OtcMedicineObserver from "../observers/OtcMedicineObserver";
-import PopoverButton from "./Buttons/PopoverButton";
-import TooltipButton from "./Buttons/TooltipButton";
-import {ReactComponent as RxIcon} from "../icons/prescription.svg";
-import {clientDOB, clientFullName} from "../utility/common";
 import ResidentEdit from "./Pages/Modals/ResidentEdit";
+import {ReactComponent as RxIcon} from "../icons/prescription.svg";
 import {ResidentRecord} from "../types/RecordTypes";
 
 /**
@@ -80,19 +79,6 @@ const App = () => {
     MedicineObserver(mm, activeClient);     // Watching: __medicine
     OtcMedicineObserver(mm);                // Watching: __otcMedicine
 
-    /**
-     * Client notes popover attached to the active client DOB button at the top of the web page.
-     */
-    const clientNotesPopover =
-        <Popover id="client-notes-popover">
-            <PopoverTitle>
-                Client Notes
-            </PopoverTitle>
-            <Popover.Content>
-                {activeClient && activeClient?.Notes}
-            </Popover.Content>
-        </Popover>
-
     return (
         <>
             <h3 style={{textAlign: "center"}} className="d-print-none">℞Chart{ }
@@ -111,32 +97,30 @@ const App = () => {
 
             {activeClient &&
             <h1
-                className="d-print-none"
+                className="d-print-none auto-center"
                 style={{textAlign: "center"}}
             >
-                <TooltipButton
-                    variant={development ? "outline-danger" : "outline-warning"}
-                    placement="left"
-                    tooltip="Print Medbox Labels"
-                    disabled={showClientRoster}
-                    onClick={() => setShowClientRoster(true)}
-                >
-                    <span style={{fontStyle: development ? "italic" : "bold"}}>
-                        {clientFullName(activeClient)}
-                    </span>
-                </TooltipButton>
+                <ButtonGroup>
+                    <ClientButton
+                        className="mr-2"
+                        clientRecord={activeClient}
+                        development={development}
+                        onSelect={(choice)=> {
+                            switch (choice) {
+                                case 'edit':
+                                    setShowClientEdit(true);
+                                    break;
+                                default:
+                                    alert(choice);
+                            }
+                        }}
+                    />
 
-                <PopoverButton
-                    defaultShow={!!activeClient.Notes}
-                    onClick={() => setShowClientEdit(true)}
-                    placement="bottom"
-                    popover={activeClient.Notes ? clientNotesPopover : undefined}
-                    variant={activeClient.Notes ? "danger" : "outline-dark"}
-                >
-                    <span style={{fontStyle: "bold"}}>
-                        <span>{clientDOB(activeClient)}</span> {activeClient.Notes && <span>🔔</span>}
-                    </span>
-                </PopoverButton>
+                    <ClientDobButton
+                        clientRecord={activeClient}
+                        development={development}
+                    />
+                </ButtonGroup>
             </h1>
             }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import React, {useGlobal, useState} from 'reactn';
+import React, {useGlobal, useState, useEffect} from 'reactn';
 
 import {ButtonGroup} from "react-bootstrap";
 
@@ -27,6 +27,7 @@ import {ResidentRecord} from "../types/RecordTypes";
 const App = () => {
     const [, setClient] = useGlobal('__client');
     const [activeClient, setActiveClient] = useGlobal('activeResident');
+    const [, setActiveTabKey] = useGlobal('activeTabKey');
     const [development] = useGlobal('development');
     const [mm] = useGlobal('medicineManager');
     const [providers] = useGlobal('providers');
@@ -34,6 +35,7 @@ const App = () => {
     const [showClientRoster, setShowClientRoster] = useState(false);
     const [showAboutPage, setShowAboutPage] = useState(false);
     const [signIn] = useGlobal('signIn');
+    const [hmisName, setHmisName] = useState('');
 
     /**
      * Initialize all the observers
@@ -79,6 +81,23 @@ const App = () => {
     MedicineObserver(mm, activeClient);     // Watching: __medicine
     OtcMedicineObserver(mm);                // Watching: __otcMedicine
 
+    /**
+     * Launch HMIS website when hmisName is populated, but first copy the name to the clipboard.
+     */
+    useEffect(() => {
+        if (hmisName?.trim().length > 0) {
+            const handleClipboardEvent = (e: ClipboardEvent) => {
+                e?.clipboardData?.setData('text/plain', (hmisName));
+                e.preventDefault();
+            }
+            document.addEventListener('copy', (e: ClipboardEvent) => handleClipboardEvent(e));
+            document.execCommand('copy');
+            window.open('https://www.clienttrack.net/utahhmis', '_blank');
+            setHmisName('');
+            return ()=> document.removeEventListener('copy', handleClipboardEvent);
+        }
+    }, [hmisName]);
+
     return (
         <>
             <h3 style={{textAlign: "center"}} className="d-print-none">℞Chart{ }
@@ -110,8 +129,15 @@ const App = () => {
                                 case 'edit':
                                     setShowClientEdit(true);
                                     break;
-                                default:
-                                    alert(choice);
+                                case 'print':
+                                    setShowClientRoster(true);
+                                    break;
+                                case 'hmis':
+                                    setHmisName(activeClient.LastName + ', ' + activeClient.FirstName);
+                                    break;
+                                case 'switch':
+                                    setActiveTabKey('resident');
+                                    break;
                             }
                         }}
                     />

--- a/src/components/Buttons/ClientButton.tsx
+++ b/src/components/Buttons/ClientButton.tsx
@@ -1,0 +1,64 @@
+import React from "reactn";
+import {clientFullName} from "../../utility/common";
+import {ResidentRecord} from "../../types/RecordTypes";
+import {Dropdown, DropdownButton} from "react-bootstrap";
+
+// @ts-ignore Some props are completely incompatible and even the type `any` doesn't make TS happy
+interface IProps {
+    className?: any
+    clientRecord: ResidentRecord
+    development: boolean
+    onSelect?: (choice: string) => void
+    disabled?: boolean
+    [key: string]: any
+}
+
+const ClientButton = (props: IProps) => {
+    const {
+        clientRecord,
+        development = true,
+        onSelect,
+        className,
+        disabled
+    } = props;
+
+    const handleClick = (choice: string) => {
+        if (onSelect) {
+            onSelect(choice);
+        }
+    }
+
+    const clientName = (
+        <span style={{fontStyle: development ? "italic" : "bold"}}>
+            {clientFullName(clientRecord)}
+        </span>
+    );
+
+    return (
+        <DropdownButton
+            variant="success"
+            title={clientName}
+            id="client-dropdown-button"
+            className={className}
+            disabled={disabled}
+        >
+            <Dropdown.Item
+                onClick={()=>handleClick('edit')}
+            >
+                Edit Client
+            </Dropdown.Item>
+            <Dropdown.Item
+                onClick={()=>handleClick('print')}
+            >
+                Print Medbox Labels
+            </Dropdown.Item>
+            <Dropdown.Item
+                onClick={()=>handleClick('hmis')}
+            >
+                Copy name to clipboard and launch HMIS
+            </Dropdown.Item>
+        </DropdownButton>
+    )
+}
+
+export default ClientButton;

--- a/src/components/Buttons/ClientButton.tsx
+++ b/src/components/Buttons/ClientButton.tsx
@@ -34,12 +34,17 @@ const ClientButton = (props: IProps) => {
         </span>
     );
 
+    /**
+     * Work-around so React 17 can be used
+     * @link https://github.com/react-bootstrap/react-bootstrap/issues/5409#issuecomment-718699584
+     */
     return (
         <DropdownButton
             variant="success"
             title={clientName}
             id="client-dropdown-button"
             className={className}
+            onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
             disabled={disabled}
         >
             <Dropdown.Item
@@ -56,6 +61,12 @@ const ClientButton = (props: IProps) => {
                 onClick={()=>handleClick('hmis')}
             >
                 Copy name to clipboard and launch HMIS
+            </Dropdown.Item>
+            <Dropdown.Divider/>
+            <Dropdown.Item
+                onClick={()=>handleClick('switch')}
+            >
+                Switch to a different client
             </Dropdown.Item>
         </DropdownButton>
     )

--- a/src/components/Buttons/ClientDobButton.tsx
+++ b/src/components/Buttons/ClientDobButton.tsx
@@ -1,0 +1,59 @@
+import React from "reactn";
+
+import {Badge, Dropdown, DropdownButton} from "react-bootstrap";
+
+import {clientDOB} from "../../utility/common";
+import {ResidentRecord} from "../../types/RecordTypes";
+
+// @ts-ignore Some props are completely incompatible and even the type `any` doesn't make TS happy
+interface IProps {
+    className?: any
+    clientRecord: ResidentRecord
+    development: boolean
+    onSelect?: (choice: string) => void
+    disabled?: boolean
+}
+
+/**
+ * ClientDobButton is a dropdown button that displays the date of birth of the given client record
+ * The dropdown shows the client notes if they have any.
+ * @param {IProps} props
+ */
+const ClientDobButton = (props: IProps) => {
+    const {
+        clientRecord,
+        development = true,
+        className,
+        disabled
+    } = props;
+
+    const clientDobComponent = (
+        <span style={{fontStyle: development ? "italic" : "bold"}}>
+            {clientRecord.Notes && <Badge variant="light">🔔</Badge>}{" "}{clientDOB(clientRecord)}
+        </span>
+    );
+
+    // @see https://stackoverflow.com/a/17887494/4323201 for getting the Dropdown.ItemText to display correctly
+    return (
+        <DropdownButton
+            className={className}
+            disabled={disabled || clientRecord.Notes == null || clientRecord?.Notes?.trim().length === 0}
+            id="client-dob-dropdown-button"
+            title={clientDobComponent}
+            variant="outline-secondary"
+        >
+            <Dropdown.Item
+                style={{whiteSpace: "normal", width: "300px"}}
+            >
+                <Dropdown.Header>
+                    <h5>Notes</h5>
+                </Dropdown.Header>
+                <Dropdown.ItemText>
+                    {clientRecord.Notes}
+                </Dropdown.ItemText>
+            </Dropdown.Item>
+        </DropdownButton>
+    )
+}
+
+export default ClientDobButton;

--- a/src/components/Buttons/ClientDobButton.tsx
+++ b/src/components/Buttons/ClientDobButton.tsx
@@ -33,12 +33,18 @@ const ClientDobButton = (props: IProps) => {
         </span>
     );
 
-    // @see https://stackoverflow.com/a/17887494/4323201 for getting the Dropdown.ItemText to display correctly
+    /**
+     * CSS Style override for getting the Dropdown.ItemText to display correctly
+     * @link https://stackoverflow.com/a/17887494/4323201
+     * Work-around so React 17 can be used
+     * @link https://github.com/react-bootstrap/react-bootstrap/issues/5409#issuecomment-718699584
+     */
     return (
         <DropdownButton
             className={className}
             disabled={disabled || clientRecord.Notes == null || clientRecord?.Notes?.trim().length === 0}
             id="client-dob-dropdown-button"
+            onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
             title={clientDobComponent}
             variant="outline-secondary"
         >

--- a/src/components/Pages/Modals/ResidentEdit.tsx
+++ b/src/components/Pages/Modals/ResidentEdit.tsx
@@ -242,7 +242,11 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
                                 value={residentInfo.Notes}
                                 name="Notes"
                                 onChange={(e) => handleOnChange(e)}
+                                className={residentInfo?.Notes?.trim().length > 500 ? 'is-invalid' : ''}
                             />
+                            <div className="invalid-feedback">
+                                Notes can only be 500 characters long. length={residentInfo?.Notes?.trim().length}
+                            </div>
                         </Col>
                     </Form.Group>
                 </Form>


### PR DESCRIPTION
- Added components:
  - ClientButton.tsx
  - ClientDobButton.tsx
  - App.tsx now imports the above buttons.
  - ClientButton allows for opening the edit modal, printing medbox labels, copying the name to the clipboard and launching HMIS, and switching clients.
  - ClientDobButton shows client notes.
  - Added workaround for dropdown buttons stopping working in React 17 due to the way mouse events are handled.
    - See https://github.com/react-bootstrap/react-bootstrap/issues/5409#issuecomment-718699584
- Closes #124
