### PR TITLE
Medicine Active checkbox and Other drug names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxchart",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": true,
   "dependencies": {
     "@types/bwip-js": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "dependencies": {
     "@types/bwip-js": "^2.1.0",
-    "@types/node": "^15.12.2",
-    "@types/react": "^17.0.11",
-    "@types/react-dom": "^17.0.7",
+    "@types/node": "^16.4.12",
+    "@types/react": "^17.0.15",
+    "@types/react-dom": "^17.0.9",
     "bootstrap": "^4.6.0",
-    "bwip-js": "^3.0.1",
+    "bwip-js": "^3.0.4",
     "frak": "^3.1.4",
     "react": "^17.0.2",
     "react-bootstrap": "^1.6.1",
@@ -16,13 +16,12 @@
     "react-new-improved-window": "^0.2.4",
     "react-scripts": "^4.0.3",
     "reactn": "^2.2.7",
-    "typescript": "^4.3.3"
+    "typescript": "^4.3.5"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "export NODE_OPTIONS=\"--max-old-space-size=1024\" && react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "lint": "tslint -p tsconfig.json"
   },
@@ -42,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "prettier": "^2.3.0",
+    "prettier": "^2.3.2",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
     "tslint-react-hooks": "^2.2.2"

--- a/src/components/Pages/Grids/MedicineDetail.tsx
+++ b/src/components/Pages/Grids/MedicineDetail.tsx
@@ -49,6 +49,7 @@ const MedicineDetail = (props: IProps): JSX.Element => {
             {onLogDrug &&
                 <td style={{textAlign: "center", verticalAlign: "middle"}}>
                     <Button
+                        disabled={!drug.Active}
                         variant="info"
                         size="sm"
                         id={"med-checkout-btn-row" + drug.Id}

--- a/src/components/Pages/ListGroups/DrugDropdown.tsx
+++ b/src/components/Pages/ListGroups/DrugDropdown.tsx
@@ -59,9 +59,9 @@ const DrugDropdown = (props: IProps): JSX.Element | null => {
      * @returns {JSX.Element}
      */
     const MedicineDropdownItems = (medicine: MedicineRecord): JSX.Element => {
-        const drug = medicine.Drug;
+        const otherNames = medicine.OtherNames ? ' (' + medicine.OtherNames + ') ' : '';
         const strength = medicine.Strength ? medicine.Strength : '';
-        const drugDetail = drug + ' ' + strength;
+        const drugDetail = medicine.Drug+ ' ' + strength + otherNames;
         const key = medicine.Id?.toString();
         return (
             <Dropdown.Item

--- a/src/components/Pages/MedicinePage.tsx
+++ b/src/components/Pages/MedicinePage.tsx
@@ -42,6 +42,7 @@ const MedicinePage = (): JSX.Element | null => {
     const [gridHeight, setGridHeight] = useState('675px');
     const [lastTaken, setLastTaken] = useState<number | null>(null);
     const [medicineList] = useGlobal('medicineList');
+    const [filteredMedicineList, setFilteredMedicineList] = useState(medicineList);
     const [otcGroupShown, setOtcGroupShown] = useState<boolean>(false);
     const [otcList] = useGlobal('otcList');
     const [otcLogList, setOtcLogList] = useState<DrugLogRecord[]>([]);
@@ -50,14 +51,14 @@ const MedicinePage = (): JSX.Element | null => {
     const [showDrugLog, setShowDrugLog] = useState<DrugLogRecord | null>(null);
     const [showMedicineEdit, setShowMedicineEdit] = useState<MedicineRecord | null>(null);
 
-    // Set the activeDrug when the medicineList changes
+    // Set the activeDrug when the filteredMedicineList changes
     useEffect(() => {
-        if (medicineList.length > 0) {
-            setActiveDrug(medicineList[0]);
+        if (filteredMedicineList.length > 0) {
+            setActiveDrug(filteredMedicineList[0]);
         } else {
             setActiveDrug(null);
         }
-    }, [medicineList]);
+    }, [filteredMedicineList]);
 
     // Calculate how many hours it has been since the activeDrug was taken and set showLastTakenWarning value
     useEffect(() => {
@@ -96,6 +97,11 @@ const MedicinePage = (): JSX.Element | null => {
             setActiveOtcDrug(null);
         }
     }, [otcList]);
+
+    // Refresh the filteredMedicineList when medicineList changes
+    useEffect(() => {
+        setFilteredMedicineList(medicineList.filter((m) => m.Active));
+    }, [medicineList]);
 
     // We only want to list the OTC drugs on this page that the resident has taken.
     useEffect(() => {
@@ -141,7 +147,6 @@ const MedicinePage = (): JSX.Element | null => {
             MedicineId: activeOtcDrug?.Id,
             Notes: ""
         } as DrugLogRecord;
-        console.log('OTC drugLogRecord', drugLogRecord);
         setShowDrugLog(drugLogRecord);
     }
 
@@ -258,7 +263,7 @@ const MedicinePage = (): JSX.Element | null => {
                             drugChanged={(drug: MedicineRecord) => setActiveDrug(drug)}
                             lastTaken={lastTaken}
                             logDrug={(amount: number) => handleLogDrugAmount(amount, activeDrug.Id as number)}
-                            medicineList={medicineList}
+                            medicineList={filteredMedicineList}
                         />
                     </Row>
                     }

--- a/src/components/Pages/Modals/MedicineEdit.tsx
+++ b/src/components/Pages/Modals/MedicineEdit.tsx
@@ -157,6 +157,7 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
             <Form.Group as={Row} controlId="otc-alert">
                 <Form.Label
                     column sm="2"
+                    style={{userSelect: "none"}}
                 >
                     <span style={{color: "red"}}><b>OTC Warning</b></span>
                 </Form.Label>
@@ -192,7 +193,7 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
                     {otcAlert}
 
                     <Form.Group as={Row}>
-                        <Form.Label column sm="2">
+                        <Form.Label column sm="2" style={{userSelect: "none"}}>
                             Drug Name
                         </Form.Label>
 
@@ -211,11 +212,11 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
                             </div>
                         </Col>
 
-                        <Form.Label column sm="1">
+                        <Form.Label column sm="1" style={{userSelect: "none"}}>
                             Strength
                         </Form.Label>
 
-                        <Col sm="4">
+                        <Col sm="2">
                             <Form.Control
                                 type="text"
                                 value={drugInfo.Strength ? drugInfo.Strength : ''}
@@ -226,8 +227,51 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
                         </Col>
                     </Form.Group>
 
+                    <Form.Group as={Row}>
+                        <Form.Label column sm="2" style={{userSelect: "none"}}>
+                            Other Names
+                        </Form.Label>
+
+                        <Col sm="9">
+                            <Form.Control
+                                ref={textInput}
+                                type="text"
+                                value={drugInfo.OtherNames}
+                                placeholder="Other names for the drug"
+                                name="OtherNames"
+                                onChange={(e) => handleOnChange(e)}
+                            />
+                        </Col>
+                    </Form.Group>
+
+                    {!drugInfo.OTC &&
+                    <Form.Group as={Row}>
+                        <Col sm="3">
+                            <Form.Label style={{userSelect: "none"}}>
+                                Active
+                            </Form.Label>
+                        </Col>
+                        <Col sm="2">
+                            <Form.Check
+                                style={{transform: "scale(2)"}}
+                                onChange={(e) => handleOnChange(e)}
+                                checked={drugInfo.Active}
+                                name="Active"
+                                tabIndex={-1}
+                            />
+                        </Col>
+                        <Col sm="6">
+                            {!drugInfo.Active &&
+                            <>
+                            <span style={{fontWeight: "bold"}}>{drugInfo.Drug}</span> will not appear in the dropdown
+                            </>
+                            }
+                        </Col>
+                    </Form.Group>
+                    }
+
                     <Form.Group as={Row} controlId="drug-Directions">
-                        <Form.Label column sm="2">
+                        <Form.Label column sm="2" style={{userSelect: "none"}}>
                             Directions
                         </Form.Label>
 
@@ -245,7 +289,7 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
 
                     {!otc &&
                     <Form.Group as={Row} controlId="otc-drug-Notes">
-                        <Form.Label column sm="2">
+                        <Form.Label column sm="2" style={{userSelect: "none"}}>
                             Notes
                         </Form.Label>
 
@@ -262,7 +306,7 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
                     }
 
                     <Form.Group as={Row} controlId="drug-barcode">
-                        <Form.Label column sm="2">
+                        <Form.Label column sm="2" style={{userSelect: "none"}}>
                             Barcode
                         </Form.Label>
 
@@ -280,13 +324,14 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
                     <Form.Group as={Row}>
                         <Form.Label
                             column sm="2"
+                            style={{userSelect: "none"}}
                         >
                             <span className={(isFillDateValid() ? '' : 'is-invalid')}>Fill Date</span>
                             <div className="invalid-feedback">
                                 Invalid Fill Date
                             </div>
                         </Form.Label>
-                        <Form.Label column sm="1">
+                        <Form.Label column sm="1" style={{userSelect: "none"}}>
                             Month
                         </Form.Label>
                         <Col sm="2">
@@ -308,7 +353,7 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
                                 Invalid Month
                             </div>
                         </Col>
-                        <Form.Label column sm="1">
+                        <Form.Label column sm="1" style={{userSelect: "none"}}>
                             Day
                         </Form.Label>
                         <Col sm="2">
@@ -331,7 +376,7 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
                                 Invalid Day
                             </div>
                         </Col>
-                        <Form.Label column sm="1">
+                        <Form.Label column sm="1" style={{userSelect: "none"}}>
                             Year
                         </Form.Label>
                         <Col sm={2}>

--- a/src/types/RecordTypes.ts
+++ b/src/types/RecordTypes.ts
@@ -30,12 +30,14 @@ export type MedicineRecord = {
     Barcode: string | null
     Directions: string | null
     Drug: string
+    OtherNames: string
     FillDateDay?: string | number
     FillDateMonth?: string
     FillDateYear?: string | number
     [key: string]: any
     Id: number | null
     Notes: string | null
+    Active: boolean
     OTC: boolean
     ResidentId?: number | null
     Strength: string | null
@@ -45,8 +47,10 @@ export const newMedicineRecord = {
     Barcode: '',
     Directions: '',
     Drug: '',
+    OtherNames: '',
     Id: null,
     Notes: '',
+    Active: true,
     ResidentId: null,
     Strength: ''
 } as MedicineRecord;


### PR DESCRIPTION
- DrugDropdown.tsx changed for the drop down items to display OtherNames field if populated
- MedicineDetail.tsx changed to disable the + Log Drug button if the medicine isn't Active
- MedicineEdit.tsx Added Active checkbox and OtherNames textbox entry; also made all the labels unselectable
- MedicinePage.tsx filters the `medicineList` based on if Active is true
- RecordTypes.ts updated for the Active and OtherNames fields
- Some dependencies updated mostly for types and the TypeScript version was bumped to 4.3.5 and removed the eject script so this **never** gets executed