### PR TITLE
Add Search :mag: Textbox to Manage Otc Tab

### DIFF
--- a/src/components/Pages/Grids/MedicineDetail.tsx
+++ b/src/components/Pages/Grids/MedicineDetail.tsx
@@ -78,6 +78,9 @@ const MedicineDetail = (props: IProps): JSX.Element => {
             {columns.includes('Drug') &&
             <td style={{verticalAlign: "middle"}}>{drug.Drug}</td>
             }
+            {columns.includes('Other') &&
+                <td style={{verticalAlign: "middle"}}>{drug.OtherNames}</td>
+            }
             {columns.includes('Strength') &&
             <td style={{verticalAlign: "middle"}}>{drug.Strength}</td>
             }


### PR DESCRIPTION
- UI :lipstick: improvement by making the search box and + OTC button a Row and putting the table as a Row.
- Search textbox with validation added that filters the `otcList`
- MedicineDetail changed to allow an Other Names column for the drugs.

Closes #147 