### PR TITLE
Create a grid specifically for ManageOtcPage

### DIFF
--- a/src/components/Pages/Grids/ManageOtcGrid.tsx
+++ b/src/components/Pages/Grids/ManageOtcGrid.tsx
@@ -1,0 +1,108 @@
+import Button from "react-bootstrap/Button";
+import Table from "react-bootstrap/Table";
+import React from "reactn";
+import {MedicineRecord} from "types/RecordTypes";
+
+interface IProps {
+    onDelete: (r: MedicineRecord) => void
+    onEdit: (r: MedicineRecord) => void
+    otcList: MedicineRecord[]
+}
+
+/**
+ * ManageOtc Table
+ * @param {IProps} props
+ * @return {JSX.Element}
+ */
+const ManageOtcGrid = (props: IProps): JSX.Element => {
+    const {
+        onDelete,
+        onEdit,
+        otcList
+    } = props;
+
+
+    const OtcRow = (drug: MedicineRecord) => {
+        return (
+            <tr
+                id={'med-detail-grid-row-' + drug.Id}
+            >
+                    <td style={{textAlign: "center", verticalAlign: "middle"}}>
+                        < Button
+                            size="sm"
+                            id={"medicine-edit-btn-row" + drug.Id}
+                            onClick={() => onEdit(drug)}
+                        >
+                            Edit
+                        </Button>
+                    </td>
+
+
+
+                    <td style={{verticalAlign: "middle"}}>{drug.Drug}</td>
+
+
+                    <td style={{verticalAlign: "middle"}}>{drug.OtherNames}</td>
+
+
+                    <td style={{verticalAlign: "middle"}}>{drug.Strength}</td>
+
+
+                    <td style={{verticalAlign: "middle"}}>{drug.Directions}</td>
+
+
+                    <td style={{verticalAlign: "middle"}}>{drug.Barcode}</td>
+
+
+                    <td style={{textAlign: 'center', verticalAlign: "middle"}}>
+                        <Button
+                            size="sm"
+                            id={"medicine-grid-delete-btn-" + drug.Id}
+                            variant="outline-danger"
+                            onClick={ ()=> onDelete(drug)}
+                            disabled={!drug.Active}
+                        >
+                            <span role="img" aria-label="delete">🗑</span>
+                        </Button>
+                    </td>
+            </tr>
+        )
+    }
+
+    return (
+    <Table
+        style={{height: "730px", overflowY: "scroll", display: "inline-block"}}
+        striped
+        bordered
+        hover
+        size="lg"
+    >
+        <thead>
+        <tr>
+            <th></th>
+            <th>
+                Drug
+            </th>
+            <th>
+                Other Names
+            </th>
+            <th>
+                Strength
+            </th>
+            <th>
+                Directions
+            </th>
+            <th>
+                Barcode
+            </th>
+            <th style={{textAlign: 'center', verticalAlign: "middle"}}>Delete</th>
+        </tr>
+        </thead>
+        <tbody>
+            {otcList.map(OtcRow)}
+        </tbody>
+    </Table>
+    )
+};
+
+export default ManageOtcGrid;

--- a/src/components/Pages/ListGroups/OtcListGroup.tsx
+++ b/src/components/Pages/ListGroups/OtcListGroup.tsx
@@ -175,6 +175,9 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                                 Drug
                             </th>
                             <th>
+                                Other Names
+                            </th>
+                            <th>
                                 Strength
                             </th>
                         </tr>
@@ -185,6 +188,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                                 activeDrug={activeOtc}
                                 columns={[
                                     'Drug',
+                                    'Other',
                                     'Strength'
                                 ]}
                                 drug={drug}

--- a/src/components/Pages/ManageOtcPage.tsx
+++ b/src/components/Pages/ManageOtcPage.tsx
@@ -1,12 +1,11 @@
+import ManageOtcGrid from "components/Pages/Grids/ManageOtcGrid";
 import Alert from "react-bootstrap/Alert";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
-import Table from "react-bootstrap/Table";
 import React, {useEffect, useGlobal, useLayoutEffect, useRef, useState} from 'reactn';
 import {MedicineRecord, newMedicineRecord} from "types/RecordTypes";
 import TooltipButton from "./Buttons/TooltipButton";
-import MedicineDetail from "./Grids/MedicineDetail";
 import Confirm from "./Modals/Confirm";
 import MedicineEdit from "./Modals/MedicineEdit";
 
@@ -118,57 +117,14 @@ const ManageOtcPage = (): JSX.Element | null => {
             </ButtonGroup>
 
             <Row>
-            <Table
-                style={{height: "730px", overflowY: "scroll", display: "inline-block"}}
-                striped
-                bordered
-                hover
-                size="lg"
-            >
-                <thead>
-                <tr>
-                    <th></th>
-                    <th>
-                        Drug
-                    </th>
-                    <th>
-                        Other Names
-                    </th>
-                    <th>
-                        Strength
-                    </th>
-                    <th>
-                        Directions
-                    </th>
-                    <th>
-                        Barcode
-                    </th>
-                    <th style={{textAlign: 'center', verticalAlign: "middle"}}>Delete</th>
-                </tr>
-                </thead>
-                <tbody>
-                {filteredOtcList.map((drug: MedicineRecord) =>
-                    <MedicineDetail
-                        drug={drug}
-                        columns={[
-                            'Drug',
-                            'Other',
-                            'Strength',
-                            'Directions',
-                            'Barcode'
-                        ]}
-                        key={'otc' + drug.Id}
-                        onDelete={(medicineRecord) => {
-                            setMedicineInfo({...medicineRecord});
-                            setShowDeleteMedicine(true);
-                        }
-                        }
-                        onEdit={onEdit}
-                        isOTC={true}
-                    />)
-                }
-                </tbody>
-            </Table>
+                <ManageOtcGrid
+                    onDelete={(medicineRecord) => {
+                        setMedicineInfo({...medicineRecord});
+                        setShowDeleteMedicine(true);
+                    }}
+                    onEdit={onEdit}
+                    otcList={filteredOtcList}
+                />
             </Row>
 
             {showMedicineEdit && medicineInfo &&


### PR DESCRIPTION
- Refactored :arrows_counterclockwise: ManageOtcPage / MedicineDetail extracting the Table and Row components putting them in ManageOtcGrid

unrelated:
- OtcListGroup updated to show the Other Names column

Closes #157 