### PR TITLE
Better UI for other drug names in dropdown

### DIFF
--- a/src/components/Pages/ListGroups/DisabledSpinner.tsx
+++ b/src/components/Pages/ListGroups/DisabledSpinner.tsx
@@ -20,7 +20,6 @@ const DisabledSpinner = (props: TProps) => {
         animation="border",
         children,
         size="sm",
-        as="span",
         role="status"
     } = {...props}
 
@@ -30,11 +29,12 @@ const DisabledSpinner = (props: TProps) => {
                 {...props}
                 animation={animation}
                 size={size}
-                as={as}
                 role={role}
                 aria-hidden="true"
+                as="span"
             >
-            </Spinner> { } {children}
+                {""}
+            </Spinner> {children}
         </>
     )
 }

--- a/src/components/Pages/ListGroups/MedDropdown.tsx
+++ b/src/components/Pages/ListGroups/MedDropdown.tsx
@@ -3,9 +3,10 @@ import DropdownButton from "react-bootstrap/DropdownButton";
 import React from 'reactn';
 import DisabledSpinner from "./DisabledSpinner";
 
-interface IDropdownItem {
+export interface IDropdownItem {
     id: number, // zero indicated a divider
     description: string
+    subtext: string | null
 }
 
 interface IProps {
@@ -54,7 +55,14 @@ const MedDropdown = (props: IProps): JSX.Element | null => {
                 active={i.id === activeId}
                 onSelect={() => onSelect(i.id)}
             >
-                {i.description}
+                <span>
+                    <span style={{display: "block"}}>{i.description}</span>
+                    {i.subtext &&
+                        <span style={{fontSize: "12px", display: "block"}}>
+                        {i.subtext}
+                    </span>
+                    }
+                </span>
             </Dropdown.Item>
         );
     };

--- a/src/components/Pages/ListGroups/MedListGroup.tsx
+++ b/src/components/Pages/ListGroups/MedListGroup.tsx
@@ -7,6 +7,7 @@ import {drawBarcode} from 'utility/drawBarcode';
 import LogButtons from '../Buttons/LogButtons';
 import ShadowBox from '../Buttons/ShadowBox';
 import MedDropdown from './MedDropdown';
+import {IDropdownItem} from "../ListGroups/MedDropdown";
 
 interface IProps {
     activeMed: MedicineRecord | null
@@ -21,11 +22,6 @@ interface IProps {
     medicineList: MedicineRecord[]
     pillboxList: PillboxRecord[]
     lastTaken: number | null
-}
-
-export interface IMedDropdownItem {
-    id: number, // zero indicates a divider
-    description: string
 }
 
 /**
@@ -57,27 +53,28 @@ const MedListGroup = (props: IProps): JSX.Element => {
     const fillDateType = (fillDateText) ? new Date(fillDateText) : null;
     const fillDateOptions = {month: '2-digit', day: '2-digit', year: 'numeric'} as Intl.DateTimeFormatOptions;
     const fillDate = (fillDateType) ? fillDateType.toLocaleString('en-US', fillDateOptions) : null;
-    const itemList = [] as IMedDropdownItem[];
+    const itemList = [] as IDropdownItem[];
 
     // Build the itemList with any pillboxes and meds from medicineList
     let pbCnt = 0;
     pillboxList.forEach(p => {
         const pillboxId = p.Id as number;
         if (!isPillboxLogToday(pillboxId)) {
-            itemList.push({id: -(pillboxId), description: p.Name}); // Pillbox have negative id
+            itemList.push({id: -(pillboxId), description: p.Name, subtext: null}); // Pillbox have negative id
             pbCnt++;
         }
     });
     if (pbCnt > 0) {
-        itemList.push({id: 0, description: "divider"});
+        itemList.push({id: 0, description: "divider", subtext: null});
     }
     medicineList.forEach(m => {
         const strength = m.Strength || '';
-        const other = m.OtherNames?.length > 0 ? `(${m.OtherNames})` : '';
-        const description = m.Drug +  ' ' + strength + ' ' + other;
+        const other = m.OtherNames?.length > 0 ? `(${m.OtherNames})` : null;
+        const description = m.Drug +  ' ' + strength;
         itemList.push({
             id: m.Id as number,
-            description
+            description,
+            subtext: other
         })
     });
 
@@ -173,9 +170,7 @@ const MedListGroup = (props: IProps): JSX.Element => {
                         <ListGroup.Item
                             style={listboxItemStyle}
                         >
-                            <ShadowBox>
                                 <b>Other Names: </b>{activeMed.OtherNames}
-                            </ShadowBox>
                         </ListGroup.Item>
                     }
 


### PR DESCRIPTION
See #170 for original issue

- MedDropdown
  - Added subtext: `string|null` to IDropdownItem interface
  - Figured out a way to show subtext in a dropdown button. See: https://stackoverflow.com/a/2703610/4323201
  - export `IDropdownItem`

- MedListGroup
  - Import `IDropdownItem`
  - Add any medications with OtherNames field populated to the dropdown list

Unrelated:

- Noticed during testing that the DisabledSpinner icon was too large.
- Reverted the code to the former commit with some modifications