### PR TITLE
DisabledSpinner UI :lipstick: Improvements

### DIFF
--- a/src/components/Pages/ListGroups/DisabledSpinner.tsx
+++ b/src/components/Pages/ListGroups/DisabledSpinner.tsx
@@ -18,24 +18,19 @@ type TProps  = Modify<IProps, {
 const DisabledSpinner = (props: TProps) => {
     const {
         animation="border",
-        children,
         size="sm",
         role="status"
     } = {...props}
 
     return (
-        <>
-            <Spinner
-                {...props}
-                animation={animation}
-                size={size}
-                role={role}
-                aria-hidden="true"
-                as="span"
-            >
-                {""}
-            </Spinner> {children}
-        </>
+        <Spinner
+            {...props}
+            animation={animation}
+            size={size}
+            role={role}
+            aria-hidden="true"
+            as="span"
+        />
     )
 }
 

--- a/src/components/Pages/ListGroups/MedDropdown.tsx
+++ b/src/components/Pages/ListGroups/MedDropdown.tsx
@@ -76,7 +76,7 @@ const MedDropdown = (props: IProps): JSX.Element | null => {
             disabled={disabled}
             onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
             size="sm"
-            title={disabled ? <DisabledSpinner>{title}</DisabledSpinner> : title}
+            title={disabled ? (<><DisabledSpinner/>{" "}{title}</>) : (title)}
             variant="primary"
         >
             {itemList.map(MedDropdownItems)}

--- a/src/components/Pages/ListGroups/OtcListGroup.tsx
+++ b/src/components/Pages/ListGroups/OtcListGroup.tsx
@@ -145,7 +145,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                         variant={lastTakenVariant}
                     >
                         <span>
-                            {disabled && <DisabledSpinner/>}
+                            {disabled && <><DisabledSpinner/>{" "}</>}
                             + Log {activeOtc ? activeOtc.Drug + ' ' + activeOtc.Strength : ""}
                         </span>
                     </Button>

--- a/src/components/Pages/ListGroups/PillboxListGroup.tsx
+++ b/src/components/Pages/ListGroups/PillboxListGroup.tsx
@@ -96,8 +96,12 @@ const PillboxListGroup = (props: IProps) => {
                 checked={activePillbox?.Id === pb.Id}
                 onChange={() => onSelect(pb.Id as number)}
             >
-                {disabled && <DisabledSpinner/>}
-                <span className="ml-2">PILLBOX: <b>{pb.Name}</b></span>
+                <span
+                    className="ml-2"
+                >
+                    {disabled && <><DisabledSpinner/>{" "}</>}
+                    PILLBOX: <b>{pb.Name}</b>
+                </span>
             </ToggleButton>
         )
     }
@@ -162,7 +166,7 @@ const PillboxListGroup = (props: IProps) => {
                                     setShowAlert(true);
                                 }}
                             >
-                                {disabled && <DisabledSpinner/>}
+                                {disabled && <><DisabledSpinner/>{" "}</>}
                                 + Log Pillbox <b>{activePillbox.Name}</b>
                                 {logTime &&
                                     <Badge


### PR DESCRIPTION
- Added space between the DisabledSpinner and the component next to it
- Removed `children` as a DisabledSpinner prop and all instances that used it that way
- Simplified the code in DisabledSpinner.tsx