### PR TITLE
LoginPage wasn't showing alert with failed credentials :lock:

### DIFF
--- a/src/components/Pages/LoginPage.tsx
+++ b/src/components/Pages/LoginPage.tsx
@@ -73,6 +73,8 @@ const LoginPage = (): JSX.Element | null => {
                             }
                         }
                     }
+                } else {
+                    await setSignIn(result);
                 }
             }
         }
@@ -142,7 +144,10 @@ const LoginPage = (): JSX.Element | null => {
                 <Alert
                     variant="warning"
                     show={signIn.success !== null && !signIn.success}
-                    onClose={() => setSignIn({apiKey: null, success: null, organization: null})}
+                    onClose={() => {
+                        setSignIn({apiKey: null, success: null, organization: null});
+                        focusRef?.current?.focus();
+                    }}
                     className="mt-4"
                     dismissible
                 >


### PR DESCRIPTION
Closes #177

Unrelated:

- Upon closing the alert focus is set to the username textbox