### PR TITLE
Pillbox UI :lipstick: Improvements

### DIFF
--- a/src/components/Pages/Grids/PillboxCard.tsx
+++ b/src/components/Pages/Grids/PillboxCard.tsx
@@ -1,7 +1,7 @@
 import Card from "react-bootstrap/Card";
 import React, {useGlobal} from "reactn";
 import {MedicineRecord, PillboxItemRecord, PillboxRecord} from "types/RecordTypes";
-import {BsColors} from "utility/common";
+import {BsColor} from "utility/common";
 import getPillboxItems, {PillRowType} from "./getPillboxItems";
 import PillboxItemGrid from "./PillboxItemGrid";
 
@@ -47,22 +47,23 @@ const PillboxCard = (props: IProp) => {
                 >
                     <span
                         style={{
-                            color: BsColors.white,
-                            backgroundColor: BsColors.primary,
+                            color: BsColor.white,
+                            backgroundColor: BsColor.primary,
                             padding: ".5rem 1rem",
                             boxSizing: "border-box",
-                            borderRadius: ".25rem"
+                            borderRadius: ".25rem",
+                            textTransform: "uppercase"
                         }}
                     >
                         {pillboxName.trim()}
                     </span>
                     <span
-                        style={{color: BsColors.success, fontWeight: "bold"}}> Drugs
+                        style={{color: BsColor.success, fontWeight: "bold"}}> Drugs
                     </span>
                     {" in the pillbox: "}
                     <span
                         style={{
-                            color: pillboxItemCount > 0 ? BsColors.success : BsColors.gray,
+                            color: pillboxItemCount > 0 ? BsColor.success : BsColor.gray,
                             fontWeight: pillboxItemCount > 0 ? "bold" : undefined
                         }}
                     >

--- a/src/components/Pages/Grids/PillboxItemGrid.tsx
+++ b/src/components/Pages/Grids/PillboxItemGrid.tsx
@@ -4,7 +4,7 @@ import Dropdown from 'react-bootstrap/Dropdown'
 import Table, {TableProps} from 'react-bootstrap/Table';
 import React from 'reactn';
 import {PillboxItemRecord} from 'types/RecordTypes';
-import {BsColors, randomString} from 'utility/common';
+import {BsColor, randomString} from 'utility/common';
 import {PillRowType} from './getPillboxItems';
 
 interface IProps extends TableProps {
@@ -36,7 +36,7 @@ const PillboxItemGrid = (props: IProps): JSX.Element | null => {
      */
     const PillRow = (pill: PillRowType): JSX.Element | null => {
         const isInPillbox = !!(pill.Quantity && pill.Quantity > 0);
-        const color = isInPillbox ? BsColors.success : undefined;
+        const color = isInPillbox ? BsColor.success : undefined;
         const domId = pill.Id ? pill.Id : randomString();
         const fontStyle = isInPillbox ? undefined : 'italic';
         const fontWeight = isInPillbox ? 'bold' : undefined;

--- a/src/components/Pages/Grids/PillboxLogGrid.tsx
+++ b/src/components/Pages/Grids/PillboxLogGrid.tsx
@@ -1,7 +1,7 @@
 import {TPillboxLog} from "components/Pages/MedicinePage";
 import Table from "react-bootstrap/Table";
 import React from 'reactn';
-import {BsColors} from "utility/common";
+import {BsColor} from "utility/common";
 
 interface IProps {
     pillboxLogList: TPillboxLog[];
@@ -34,7 +34,7 @@ const PillboxLogGrid = (props: IProps) => {
                         minute: '2-digit'
                     }) : '';
                 return (
-                    <tr style={{fontWeight: "bold", color: BsColors.success}}>
+                    <tr style={{fontWeight: "bold", color: BsColor.success}}>
                         <td>
                             {tpbl.Drug} {" "} {tpbl.Strength}
                         </td>

--- a/src/components/Pages/MedicinePage.tsx
+++ b/src/components/Pages/MedicinePage.tsx
@@ -482,6 +482,7 @@ const MedicinePage = (props: IProps): JSX.Element | null => {
                             <PillboxListGroup
                                 activePillbox={activePillbox}
                                 disabled={isBusy}
+                                medicineList={medicineList}
                                 onSelect={id => setActivePillbox(pillboxList.find(pb => pb.Id === id) || null)}
                                 onEdit={r => savePillbox(r)}
                                 onDelete={id => deletePillbox(id)}

--- a/src/components/Pages/Toasts/DrugLogToast.tsx
+++ b/src/components/Pages/Toasts/DrugLogToast.tsx
@@ -1,7 +1,7 @@
 import Toast from "react-bootstrap/Toast";
 import React from "reactn";
 import {DrugLogRecord, MedicineRecord} from "types/RecordTypes";
-import {BsColors, getDrugName} from "utility/common";
+import {BsColor, getDrugName} from "utility/common";
 
 interface IProps {
     toast: DrugLogRecord[]
@@ -25,7 +25,7 @@ const DrugLogToast = (props: IProps) => {
             top: 0.95,
             right: 0.95,
             color: "#fff",
-            backgroundColor: BsColors.success
+            backgroundColor: BsColor.success
         }}
         onClose={() => onClose()}
         show={show}

--- a/src/utility/common.ts
+++ b/src/utility/common.ts
@@ -425,7 +425,7 @@ export const multiSort = (array: IArrayGeneric, sortObject: SortObject): [] => {
 /**
  * Bootstrap default colors as an enum
  */
-export enum BsColors {
+export enum BsColor {
     blue = "#007bff",
     cyan = "#17a2b8",
     danger = "#dc3545",


### PR DESCRIPTION
- Increased the size of the pillbox radio buttons
- Split the radio :radio: buttons and pillbox content into two columns in PillboxListGroup. Left column is the radio button selection and right column is a Card showing pills in the pillbox
- If no drugs are in the active pillbox then the card has instructions to the user to add pill quantities to the pillbox
- `medicineList` added as a prop to PillboxListGroup
- Pillbox names are forced to uppercase via CSS

 Unrelated:

 - `BsColors` enum changed to `BsColor` in common.ts and any module using this updated to the new name
