### PR TITLE
Pillbox logging and UI Improvements

### DIFF
--- a/src/components/Pages/Grids/DrugLogHistoryGrid.tsx
+++ b/src/components/Pages/Grids/DrugLogHistoryGrid.tsx
@@ -1,7 +1,7 @@
 import Button from 'react-bootstrap/Button';
 import Table from 'react-bootstrap/Table';
 import React from 'reactn';
-import {DrugLogRecord, MedicineRecord} from "types/RecordTypes";
+import {DrugLogRecord, MedicineRecord} from 'types/RecordTypes';
 import {
     calculateLastTaken,
     getBsColor,
@@ -9,13 +9,13 @@ import {
     getLastTakenVariant,
     getObjectByProperty,
     isToday
-} from "utility/common";
+} from 'utility/common';
 
 interface IProps {
-    drugLog: DrugLogRecord[]
-    medicineList: MedicineRecord[]
-    onDelete: (r: DrugLogRecord) => void
-    onEdit: (r: DrugLogRecord) => void
+    drugLog: DrugLogRecord[];
+    medicineList: MedicineRecord[];
+    onDelete: (r: DrugLogRecord) => void;
+    onEdit: (r: DrugLogRecord) => void;
 }
 
 /**
@@ -24,12 +24,7 @@ interface IProps {
  * @return {JSX.Element}
  */
 const DrugLogHistoryGrid = (props: IProps): JSX.Element => {
-    const {
-        drugLog = [],
-        medicineList = [],
-        onDelete,
-        onEdit
-    } = props;
+    const {drugLog = [], medicineList = [], onDelete, onEdit} = props;
 
     /**
      * Returns the value of the drug column for the given drugId
@@ -45,7 +40,7 @@ const DrugLogHistoryGrid = (props: IProps): JSX.Element => {
             }
         }
         return null;
-    }
+    };
 
     /**
      * Child component for the table for each drug that has been logged.
@@ -61,14 +56,10 @@ const DrugLogHistoryGrid = (props: IProps): JSX.Element => {
         // Figure out medicine field values
         const isOtc = drugColumnLookup(drug.MedicineId, 'OTC');
         let drugName = drugColumnLookup(drug.MedicineId, 'Drug');
+        const drugActive = medicineList.find((m) => m.Id === drug.MedicineId && m.Active);
         const medicineNotes = drugColumnLookup(drug.MedicineId, 'Notes');
         const medicineDirections = drugColumnLookup(drug.MedicineId, 'Directions');
-        const drugDetails =
-            medicineNotes && medicineNotes.trim().length >0
-                ?
-                medicineNotes
-                :
-                medicineDirections || '';
+        const drugDetails = medicineNotes && medicineNotes.trim().length > 0 ? medicineNotes : medicineDirections || '';
 
         if (!drugName || drugName.length === 0) {
             drugName = 'UNKNOWN - Medicine removed!';
@@ -81,124 +72,119 @@ const DrugLogHistoryGrid = (props: IProps): JSX.Element => {
         const variant = getLastTakenVariant(lastTaken);
         const variantColor = getBsColor(variant);
         const fontWeight = isToday(updatedDate) ? 'bold' : undefined;
+        const strikeThrough = drugActive ? undefined : 'line-through';
 
         return (
             <tr
                 key={'druglog-history-grid-row-' + drug.Id}
                 id={'druglog-history-grid-row-' + drug.Id}
-                style={{color: variantColor}}
+                style={{color: variantColor, textDecoration: strikeThrough}}
             >
-                <td style={{textAlign: 'center', verticalAlign: "middle"}}>
-                    <Button
-                        className="d-print-none"
-                        size="sm"
-                        onClick={() => onEdit(drug)}
-                    >
+                <td style={{textAlign: 'center', verticalAlign: 'middle'}}>
+                    <Button className="d-print-none" size="sm" onClick={() => onEdit(drug)}>
                         Edit
                     </Button>
                 </td>
 
-                <td style={{verticalAlign: "middle", fontWeight}}>
-                    <span>{drugName}</span> <span>{drugStrength}</span> <span>{isOtc ? " (OTC)" : ""}</span>
+                <td style={{verticalAlign: 'middle', fontWeight}}>
+                    <span style={{color: variantColor, fontStyle: strikeThrough ? 'italic' : undefined}}>
+                        {drugName}
+                    </span>{' '}
+                    <span>{drugStrength}</span> <span>{isOtc ? ' (OTC)' : ''}</span>
                 </td>
 
-                <td style={{
-                    textAlign: 'center',
-                    verticalAlign: "middle",
-                    fontWeight
-                }}>
+                <td
+                    style={{
+                        textAlign: 'center',
+                        verticalAlign: 'middle',
+                        fontWeight
+                    }}
+                >
                     {getFormattedDate(updatedDate)}
                 </td>
 
-                <td style={{
-                    textAlign: 'center',
-                    verticalAlign: "middle",
-                    fontWeight
-                }}>
-                    {drug.PillboxItemId && <span>{"💊 "}</span>} <b>{drug.Notes}</b>
+                <td
+                    style={{
+                        textAlign: 'center',
+                        verticalAlign: 'middle',
+                        fontWeight
+                    }}
+                >
+                    {drug.PillboxItemId && <span>{'💊 '}</span>} <b>{drug.Notes}</b>
                 </td>
 
-                <td style={{
-                    textAlign: 'center',
-                    verticalAlign: "middle",
-                    fontWeight
-                }}>
+                <td
+                    style={{
+                        textAlign: 'center',
+                        verticalAlign: 'middle',
+                        fontWeight
+                    }}
+                >
                     <b>{drug.Out}</b>
                 </td>
 
-                <td style={{
-                    textAlign: 'center',
-                    verticalAlign: "middle",
-                    fontWeight
-                }}>
+                <td
+                    style={{
+                        textAlign: 'center',
+                        verticalAlign: 'middle',
+                        fontWeight
+                    }}
+                >
                     <b>{drug.In}</b>
                 </td>
 
-                <td>
-                    {drugDetails}
-                </td>
+                <td>{drugDetails}</td>
 
-                <td style={{textAlign: 'center', verticalAlign: "middle"}}>
+                <td style={{textAlign: 'center', verticalAlign: 'middle'}}>
                     <Button
                         className="d-print-none"
                         size="sm"
-                        id={"drug-grid-delete-btn-" + drug.Id}
+                        id={'drug-grid-delete-btn-' + drug.Id}
                         variant="outline-danger"
                         onClick={() => onDelete(drug)}
                     >
-                        <span role="img" aria-label="delete">🗑️</span>
+                        <span role="img" aria-label="delete">
+                            🗑️
+                        </span>
                     </Button>
                 </td>
-
             </tr>
-        )
-    }
+        );
+    };
 
     return (
-        <Table
-            style={{wordWrap: "break-word"}}
-            striped
-            bordered
-            hover
-            size="sm"
-        >
+        <Table style={{wordWrap: 'break-word'}} striped bordered hover size="sm">
             <thead>
                 <tr>
                     <th></th>
 
-                    <th>
-                        Drug
-                    </th>
+                    <th>Drug</th>
 
-                    <th style={{textAlign: 'center', verticalAlign: "middle"}}>
+                    <th style={{textAlign: 'center', verticalAlign: 'middle'}}>
                         <span>Taken</span>
                     </th>
 
-                    <th style={{textAlign: 'center', verticalAlign: "middle"}}>
+                    <th style={{textAlign: 'center', verticalAlign: 'middle'}}>
                         <span>Amount/Notes</span>
                     </th>
 
-                    <th style={{textAlign: 'center', verticalAlign: "middle"}}>
+                    <th style={{textAlign: 'center', verticalAlign: 'middle'}}>
                         <span>Out</span>
                     </th>
 
-                    <th style={{textAlign: 'center', verticalAlign: "middle"}}>
+                    <th style={{textAlign: 'center', verticalAlign: 'middle'}}>
                         <span>In</span>
                     </th>
 
-                    <th>
-                        Details
-                    </th>
+                    <th>Details</th>
 
                     <th></th>
                 </tr>
             </thead>
 
-            <tbody>
-                {drugLog.map(DrugRow)}
-            </tbody>
+            <tbody>{drugLog.map(DrugRow)}</tbody>
         </Table>
-    )
-}
+    );
+};
 
 export default DrugLogHistoryGrid;

--- a/src/components/Pages/Grids/ManageDrugGrid.tsx
+++ b/src/components/Pages/Grids/ManageDrugGrid.tsx
@@ -1,15 +1,15 @@
-import Badge from "react-bootstrap/Badge";
-import Button from "react-bootstrap/Button";
-import Table from "react-bootstrap/Table";
-import React from "reactn";
-import {MedicineRecord} from "types/RecordTypes";
+import Badge from 'react-bootstrap/Badge';
+import Button from 'react-bootstrap/Button';
+import Table from 'react-bootstrap/Table';
+import React from 'reactn';
+import {MedicineRecord} from 'types/RecordTypes';
 
 interface IProps {
-    onDelete: (r: MedicineRecord) => void
-    onEdit: (r: MedicineRecord) => void
-    onLogDrug: (r: MedicineRecord) => void
-    medicineList: MedicineRecord[]
-    checkoutList: MedicineRecord[]
+    onDelete: (r: MedicineRecord) => void;
+    onEdit: (r: MedicineRecord) => void;
+    onLogDrug: (r: MedicineRecord) => void;
+    medicineList: MedicineRecord[];
+    checkoutList: MedicineRecord[];
 }
 
 /**
@@ -18,132 +18,86 @@ interface IProps {
  * @return {JSX.Element}
  */
 const ManageDrugGrid = (props: IProps): JSX.Element => {
-    const {
-        checkoutList,
-        onDelete,
-        onEdit,
-        onLogDrug,
-        medicineList
-    } = props;
+    const {checkoutList, onDelete, onEdit, onLogDrug, medicineList} = props;
 
     /**
      * Table row component for each medicine record
      * @param {MedicineRecord} drug
      */
     const TableRow = (drug: MedicineRecord) => {
-        const hasCheckout = checkoutList.find(m => m.Id === drug.Id);
+        const hasCheckout = checkoutList.find((m) => m.Id === drug.Id);
 
         return (
             <tr
                 id={'manage-drug-grid-row-' + drug.Id}
-                style={{fontStyle: !drug.Active ? 'italic' : 'normal'}}
+                style={{textDecoration: !drug.Active ? 'line-through' : undefined}}
             >
-                <td style={{textAlign: "center", verticalAlign: "middle"}}>
-                    < Button
-                        size="sm"
-                        id={"manage-drug-grid-edit-btn-" + drug.Id}
-                        onClick={() => onEdit(drug)}
-                    >
+                <td style={{textAlign: 'center', verticalAlign: 'middle'}}>
+                    <Button size="sm" id={'manage-drug-grid-edit-btn-' + drug.Id} onClick={() => onEdit(drug)}>
                         Edit
                     </Button>
                 </td>
 
-                <td style={{textAlign: "center", verticalAlign: "middle"}}>
+                <td style={{textAlign: 'center', verticalAlign: 'middle'}}>
                     <Button
                         disabled={!drug.Active}
                         variant="info"
                         size="sm"
-                        id={"manage-drug-grid-checkout-btn-" + drug.Id}
+                        id={'manage-drug-grid-checkout-btn-' + drug.Id}
                         onClick={() => onLogDrug(drug)}
                     >
                         + Log Drug {!drug.Active && <Badge>🚫</Badge>}
                     </Button>
                 </td>
 
-                <td
-                    style={{verticalAlign: "middle"}}
-                >
-                    <span>{hasCheckout && <Badge>❎</Badge>} {drug.Drug}</span>
+                <td style={{verticalAlign: 'middle'}}>
+                    <span>
+                        {hasCheckout && <Badge>❎</Badge>} {drug.Drug}
+                    </span>
                 </td>
 
-                <td
-                    style={{verticalAlign: "middle"}}
-                >
-                    {drug.Strength}
-                </td>
+                <td style={{verticalAlign: 'middle'}}>{drug.Strength}</td>
 
-                <td
-                    style={{verticalAlign: "middle"}}
-                >
-                    {drug.Directions}
-                </td>
+                <td style={{verticalAlign: 'middle'}}>{drug.Directions}</td>
 
-                <td
-                    style={{verticalAlign: "middle"}}>
-                    {drug.Notes}
-                </td>
+                <td style={{verticalAlign: 'middle'}}>{drug.Notes}</td>
 
-                <td
-                    style={{verticalAlign: "middle"}}
-                >
-                    {drug.Barcode}
-                </td>
+                <td style={{verticalAlign: 'middle'}}>{drug.Barcode}</td>
 
-                <td
-                    style={{textAlign: 'center', verticalAlign: "middle"}}
-                >
+                <td style={{textAlign: 'center', verticalAlign: 'middle'}}>
                     <Button
                         size="sm"
-                        id={"manage-drug-grid-delete-btn" + drug.Id}
-                        variant={"outline-warning"}
+                        id={'manage-drug-grid-delete-btn' + drug.Id}
+                        variant={'outline-warning'}
                         onClick={() => onDelete(drug)}
                         disabled={!drug.Active}
                     >
-                        <span role="img" aria-label="delete">{"🚫"}</span>
+                        <span role="img" aria-label="delete">
+                            {'🚫'}
+                        </span>
                     </Button>
                 </td>
             </tr>
-        )
-    }
+        );
+    };
 
     return (
-        <Table
-            striped
-            bordered
-            hover
-            size="sm"
-        >
+        <Table striped bordered hover size="sm">
             <thead>
-            <tr>
-                <th></th>
-                {/* Edit */}
-                <th></th>
-                {/* Checkout */}
-                <th>
-                    Drug
-                </th>
-                <th>
-                    Strength
-                </th>
-                <th>
-                    Directions
-                </th>
-                <th>
-                    Notes
-                </th>
-                <th>
-                    Barcode
-                </th>
-                <th style={{textAlign: 'center', verticalAlign: "middle"}}>
-                    Deactivate
-                </th>
-            </tr>
+                <tr>
+                    <th>{/* Edit */}</th>
+                    <th>{/* Checkout */}</th>
+                    <th>Drug</th>
+                    <th>Strength</th>
+                    <th>Directions</th>
+                    <th>Notes</th>
+                    <th>Barcode</th>
+                    <th style={{textAlign: 'center', verticalAlign: 'middle'}}>Deactivate</th>
+                </tr>
             </thead>
-            <tbody>
-                {medicineList.map(TableRow)}
-            </tbody>
+            <tbody>{medicineList.map(TableRow)}</tbody>
         </Table>
-    )
-}
+    );
+};
 
 export default ManageDrugGrid;

--- a/src/components/Pages/Grids/PillboxLogGrid.tsx
+++ b/src/components/Pages/Grids/PillboxLogGrid.tsx
@@ -32,10 +32,13 @@ const PillboxLogGrid = (props: IProps) => {
                               minute: '2-digit'
                           })
                         : '';
+                    const strikeThrough = log.Active ? undefined : 'line-through';
                     return (
                         <tr style={{fontWeight: 'bold', color: BsColor.success}}>
                             <td>
-                                {log.Drug} {log.Strength}
+                                <span style={{textDecoration: strikeThrough}}>
+                                    {log.Drug} {log.Strength}
+                                </span>
                             </td>
                             <td>
                                 {'💊 '} {log.Notes}

--- a/src/components/Pages/ListGroups/MedListGroup.tsx
+++ b/src/components/Pages/ListGroups/MedListGroup.tsx
@@ -1,7 +1,7 @@
 import Button from 'react-bootstrap/Button';
 import ListGroup from 'react-bootstrap/ListGroup';
 import React, {useEffect} from 'reactn';
-import {MedicineRecord, newMedicineRecord, PillboxRecord} from 'types/RecordTypes';
+import {MedicineRecord, newMedicineRecord} from 'types/RecordTypes';
 import {getLastTakenVariant, randomString} from 'utility/common';
 import {drawBarcode} from 'utility/drawBarcode';
 import LogButtons from '../Buttons/LogButtons';
@@ -16,11 +16,10 @@ interface IProps {
     editMedicine: (m: MedicineRecord) => void;
     logDrug: (n: number) => void;
     itemChanged: (i: number) => void;
+    itemList: IDropdownItem[];
     canvasUpdated?: (c: HTMLCanvasElement) => void;
     canvasId?: string;
     disabled?: boolean;
-    medicineList: MedicineRecord[];
-    pillboxList: PillboxRecord[];
     lastTaken: number | null;
 }
 
@@ -37,11 +36,10 @@ const MedListGroup = (props: IProps): JSX.Element => {
         editMedicine,
         logDrug,
         itemChanged,
+        itemList,
         canvasUpdated,
         canvasId = randomString(),
         disabled = false,
-        medicineList,
-        pillboxList,
         lastTaken = null
     } = props;
 
@@ -54,31 +52,6 @@ const MedListGroup = (props: IProps): JSX.Element => {
     const fillDateType = fillDateText ? new Date(fillDateText) : null;
     const fillDateOptions = {month: '2-digit', day: '2-digit', year: 'numeric'} as Intl.DateTimeFormatOptions;
     const fillDate = fillDateType ? fillDateType.toLocaleString('en-US', fillDateOptions) : null;
-    const itemList = [] as IDropdownItem[];
-
-    // Build the itemList with any pillboxes and meds from medicineList
-    let pbCnt = 0;
-    pillboxList.forEach((p) => {
-        itemList.push({
-            id: -(p.Id as number),
-            description: p.Name.toUpperCase(),
-            subtext: null
-        }); // Pillbox have negative id
-        pbCnt++;
-    });
-    if (pbCnt > 0) {
-        itemList.push({id: 0, description: 'divider', subtext: null});
-    }
-    medicineList.forEach((m) => {
-        const strength = m.Strength || '';
-        const other = m.OtherNames?.length > 0 ? `(${m.OtherNames})` : null;
-        const description = m.Drug + ' ' + strength;
-        itemList.push({
-            id: m.Id as number,
-            description,
-            subtext: other
-        });
-    });
 
     // Update the barcode image if the barcode has changed
     useEffect(() => {

--- a/src/components/Pages/ManageDrugPage.tsx
+++ b/src/components/Pages/ManageDrugPage.tsx
@@ -1,20 +1,20 @@
-import ManageDrugGrid from "components/Pages/Grids/ManageDrugGrid";
-import CheckoutListGroup from "components/Pages/ListGroups/CheckoutListGroup";
-import DrugLogToast from "components/Pages/Toasts/DrugLogToast";
-import Badge from "react-bootstrap/Badge";
-import Button from "react-bootstrap/Button";
-import Form from "react-bootstrap/Form";
-import Row from "react-bootstrap/Row";
+import ManageDrugGrid from 'components/Pages/Grids/ManageDrugGrid';
+import CheckoutListGroup from 'components/Pages/ListGroups/CheckoutListGroup';
+import DrugLogToast from 'components/Pages/Toasts/DrugLogToast';
+import Badge from 'react-bootstrap/Badge';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
 import React, {useGlobal, useState} from 'reactn';
-import {DrugLogRecord, MedicineRecord, newDrugLogRecord, newMedicineRecord} from "types/RecordTypes";
-import {getCheckoutList, getDrugName} from "utility/common";
-import TabContent from "../../styles/common.css";
-import TooltipButton from "./Buttons/TooltipButton";
-import DrugLogEdit from "./Modals/DrugLogEdit";
-import MedicineEdit from "./Modals/MedicineEdit";
+import {DrugLogRecord, MedicineRecord, newDrugLogRecord, newMedicineRecord} from 'types/RecordTypes';
+import {getCheckoutList, getDrugName} from 'utility/common';
+import TabContent from '../../styles/common.css';
+import TooltipButton from './Buttons/TooltipButton';
+import DrugLogEdit from './Modals/DrugLogEdit';
+import MedicineEdit from './Modals/MedicineEdit';
 
 interface IProps {
-    activeTabKey: string
+    activeTabKey: string;
 }
 
 /**
@@ -29,14 +29,13 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
     const [medicineList, setMedicineList] = useGlobal('medicineList');
     const [mm] = useGlobal('medicineManager');
     const [otcList, setOtcList] = useGlobal('otcList');
+    const [pillboxItemList, setPillboxItemList] = useGlobal('pillboxItemList');
     const [showCheckoutModal, setShowCheckoutModal] = useState<DrugLogRecord | null>(null);
     const [showCheckoutPrint, setShowCheckoutPrint] = useState(false);
     const [showMedicineEdit, setShowMedicineEdit] = useState(false);
     const [toast, setToast] = useState<DrugLogRecord[] | null>(null);
 
-    const {
-        activeTabKey
-    } = props;
+    const {activeTabKey} = props;
 
     // If this tab isn't active then don't render
     if (activeTabKey !== 'manage') return null;
@@ -51,7 +50,7 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
         const drugs = await mm.loadDrugLog(clientId, 5);
         await setDrugLogList(drugs);
         return r;
-    }
+    };
 
     /**
      * Given a MedicineRecord Update or Insert the record and rehydrate the globalMedicineList
@@ -59,6 +58,24 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
      * @param {number} clientId
      */
     const saveMedicine = async (med: MedicineRecord, clientId: number) => {
+        /**
+         * Remove all the PillboxItems when a medicine is marked as inactive
+         * @param {number} medicineId
+         */
+        const removeInactivePillboxItems = async (medicineId: number) => {
+            let delCount = 0;
+            pillboxItemList.forEach((pbi) => {
+                const removePillboxItems = async () => {
+                    if (pbi.MedicineId === medicineId) {
+                        await mm.deletePillboxItem(pbi.Id as number);
+                        delCount++;
+                    }
+                };
+                removePillboxItems();
+            });
+            return delCount;
+        };
+
         const m = await mm.updateMedicine(med);
         const ml = await mm.loadMedicineList(clientId);
         await setMedicineList(ml);
@@ -68,25 +85,42 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
             const ol = await mm.loadOtcList();
             await setOtcList(ol);
         }
+
+        // If the medicine has been set to inactive then refresh the drug log and remove from any pillboxItems
+        if (!m.Active) {
+            const dl = await mm.loadDrugLog(activeClient?.Id as number, 5);
+            await setDrugLogList(dl);
+
+            if (!m.Active) {
+                removeInactivePillboxItems(m.Id as number).then((delCount) => {
+                    if (delCount > 0) {
+                        mm.loadPillboxItemList(activeClient?.Id as number).then((pbil) => setPillboxItemList(pbil));
+                    }
+                });
+            }
+        }
+
         return m;
-    }
+    };
 
     /**
      * Fires when the Edit button is clicked
      * @param {MedicineRecord | null} medicine
      */
     const onEdit = (medicine: MedicineRecord | null) => {
-        const medicineInfo = (medicine) ? {...medicine} : {
-            ...newMedicineRecord,
-            OTC: false,
-            ResidentId: activeClient?.Id,
-            FillDateDay: "",
-            FillDateMonth: "",
-            FillDateYear: ""
-        };
+        const medicineInfo = medicine
+            ? {...medicine}
+            : {
+                  ...newMedicineRecord,
+                  OTC: false,
+                  ResidentId: activeClient?.Id,
+                  FillDateDay: '',
+                  FillDateMonth: '',
+                  FillDateYear: ''
+              };
         setMedicineInfo(medicineInfo);
         setShowMedicineEdit(true);
-    }
+    };
 
     /**
      * Handle when user clicks on the + Log Drug from the Medicine Detail table
@@ -102,7 +136,7 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
             drugLog.MedicineId = r.Id as number;
         }
         setShowCheckoutModal(drugLog);
-    }
+    };
 
     /**
      * Convenience function to get drug name
@@ -111,16 +145,16 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
      */
     const drugName = (medicineId: number): string | undefined => {
         return getDrugName(medicineId, medicineList.concat(otcList));
-    }
+    };
 
     const checkoutList = getCheckoutList(drugLogList);
 
     /**
      * Return a MedicineRecord[] array of all medicines that have Out populated and was logged today
      */
-    const medicineWithCheckout = medicineList.filter(m => {
-        return checkoutList.find(c => c.MedicineId === m.Id)
-    })
+    const medicineWithCheckout = medicineList.filter((m) => {
+        return checkoutList.find((c) => c.MedicineId === m.Id);
+    });
 
     return (
         <Form className={TabContent}>
@@ -140,49 +174,41 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
                     size="sm"
                     variant="info"
                     disabled={checkoutList.length === 0 || showCheckoutPrint}
-                    onClick={() =>setShowCheckoutPrint(true)}
-
+                    onClick={() => setShowCheckoutPrint(true)}
                 >
-                    Print Medicine Checkout {
-                    checkoutList.length && <Badge variant="secondary">{checkoutList.length}</Badge>
-                }
+                    Print Medicine Checkout{' '}
+                    {checkoutList.length && <Badge variant="secondary">{checkoutList.length}</Badge>}
                 </Button>
             </Row>
 
-            {showCheckoutPrint && activeClient &&
+            {showCheckoutPrint && activeClient && (
                 <Row className="mt-2">
-                <CheckoutListGroup
-                    onClose={() => setShowCheckoutPrint(false)}
-                    checkoutList={checkoutList}
-                    medicineList={medicineList}
-                    activeClient={activeClient}
-                />
+                    <CheckoutListGroup
+                        onClose={() => setShowCheckoutPrint(false)}
+                        checkoutList={checkoutList}
+                        medicineList={medicineList}
+                        activeClient={activeClient}
+                    />
                 </Row>
-            }
+            )}
 
-            {!showCheckoutPrint &&
+            {!showCheckoutPrint && (
                 <Row className="mt-2 d-print-none">
                     <ManageDrugGrid
                         checkoutList={medicineWithCheckout}
-                        onDelete={(mr => {
+                        onDelete={(mr) => {
                             const med = {...mr};
                             med.Active = false;
-                            saveMedicine(med, activeClient?.Id as number)
-                                .then(m => {
-                                    if (!m.Active) {
-                                        mm.loadDrugLog(activeClient?.Id as number, 5)
-                                            .then(dl => setDrugLogList(dl))
-                                    }
-                                })
-                        })}
+                            saveMedicine(med, activeClient?.Id as number);
+                        }}
                         onEdit={(m) => onEdit(m)}
                         onLogDrug={(d) => handleLogDrug(d)}
                         medicineList={medicineList}
                     />
                 </Row>
-            }
+            )}
 
-            {showMedicineEdit && medicineInfo &&
+            {showMedicineEdit && medicineInfo && (
                 <MedicineEdit
                     show={showMedicineEdit}
                     onClose={(m) => {
@@ -191,20 +217,20 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
                     }}
                     drugInfo={medicineInfo}
                 />
-            }
+            )}
 
-            {showCheckoutModal && activeClient?.Id &&
+            {showCheckoutModal && activeClient?.Id && (
                 <DrugLogEdit
-                    drugName={drugName(showCheckoutModal.MedicineId) || "[unknown]"}
+                    drugName={drugName(showCheckoutModal.MedicineId) || '[unknown]'}
                     drugLogInfo={showCheckoutModal}
                     onClose={(dl) => {
                         setShowCheckoutModal(null);
-                        if (dl) saveDrugLog(dl, activeClient.Id as number).then(r => setToast([r]));
+                        if (dl) saveDrugLog(dl, activeClient.Id as number).then((r) => setToast([r]));
                     }}
                     onHide={() => setShowCheckoutModal(null)}
                     show={true}
                 />
-            }
+            )}
 
             <DrugLogToast
                 toast={toast as DrugLogRecord[]}
@@ -213,7 +239,7 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
                 onClose={() => setToast(null)}
             />
         </Form>
-    )
-}
+    );
+};
 
 export default ManageDrugPage;

--- a/src/components/Pages/ManageOtcPage.tsx
+++ b/src/components/Pages/ManageOtcPage.tsx
@@ -1,16 +1,16 @@
-import ManageOtcGrid from "components/Pages/Grids/ManageOtcGrid";
-import Alert from "react-bootstrap/Alert";
-import ButtonGroup from "react-bootstrap/ButtonGroup";
-import Form from "react-bootstrap/Form";
-import Row from "react-bootstrap/Row";
+import ManageOtcGrid from 'components/Pages/Grids/ManageOtcGrid';
+import Alert from 'react-bootstrap/Alert';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
 import React, {useEffect, useGlobal, useRef, useState} from 'reactn';
-import {MedicineRecord, newMedicineRecord} from "types/RecordTypes";
-import TooltipButton from "./Buttons/TooltipButton";
-import Confirm from "./Modals/Confirm";
-import MedicineEdit from "./Modals/MedicineEdit";
+import {MedicineRecord, newMedicineRecord} from 'types/RecordTypes';
+import TooltipButton from './Buttons/TooltipButton';
+import Confirm from './Modals/Confirm';
+import MedicineEdit from './Modals/MedicineEdit';
 
 interface IProps {
-    activeTabKey: string
+    activeTabKey: string;
 }
 
 /**
@@ -33,15 +33,17 @@ const ManageOtcPage = (props: IProps): JSX.Element | null => {
     // Set focus to the Search textbox when this page becomes active
     useEffect(() => {
         focusRef?.current?.focus();
-    })
+    });
 
     // Search filter side effect
     useEffect(() => {
         if (searchText.length > 0) {
-            const filter = otcList.filter(o => {
-                return o.Drug.toLowerCase().includes(searchText.toLowerCase()) ||
+            const filter = otcList.filter((o) => {
+                return (
+                    o.Drug.toLowerCase().includes(searchText.toLowerCase()) ||
                     o.OtherNames?.toLowerCase().includes(searchText.toLowerCase())
-            })
+                );
+            });
 
             if (filter.length > 0) {
                 setFilteredOtcList(filter);
@@ -54,7 +56,7 @@ const ManageOtcPage = (props: IProps): JSX.Element | null => {
             setSearchIsValid(false);
             setFilteredOtcList(otcList);
         }
-    }, [otcList, searchText])
+    }, [otcList, searchText]);
 
     // If this tab isn't active then don't render
     if (props.activeTabKey !== 'manage-otc') return null;
@@ -68,30 +70,22 @@ const ManageOtcPage = (props: IProps): JSX.Element | null => {
         const ol = await mm.loadOtcList();
         await setOtcList(ol);
         return m;
-    }
+    };
 
     /**
      * Fires when the Edit button is clicked
      * @param {MedicineRecord | null} medicine
      */
     const onEdit = (medicine?: MedicineRecord | null) => {
-        const medicineInfo = (medicine) ? {...medicine} : {...newMedicineRecord, OTC: true};
+        const medicineInfo = medicine ? {...medicine} : {...newMedicineRecord, OTC: true};
         setMedicineInfo(medicineInfo);
         setShowMedicineEdit(true);
-    }
+    };
 
     return (
         <>
-            <ButtonGroup
-                className="mb-2"
-                as={Row}
-            >
-                <TooltipButton
-                    tooltip="Manually Add New OTC"
-                    size="sm"
-                    variant="info"
-                    onClick={() => onEdit(null)}
-                >
+            <ButtonGroup className="mb-2" as={Row}>
+                <TooltipButton tooltip="Manually Add New OTC" size="sm" variant="info" onClick={() => onEdit(null)}>
                     + OTC
                 </TooltipButton>
 
@@ -99,7 +93,7 @@ const ManageOtcPage = (props: IProps): JSX.Element | null => {
                     autoFocus
                     className="ml-2"
                     id="medicine-page-search-text"
-                    style={{width: "220px"}}
+                    style={{width: '220px'}}
                     isValid={searchIsValid}
                     ref={focusRef}
                     type="search"
@@ -125,63 +119,57 @@ const ManageOtcPage = (props: IProps): JSX.Element | null => {
                 />
             </Row>
 
-            {showMedicineEdit && medicineInfo &&
-            /* MedicineEdit Modal */
-            <MedicineEdit
-                show={showMedicineEdit}
-                onClose={(r) => {
-                    setShowMedicineEdit(false);
-                    if (r) {
-                        saveOtcMedicine(r);
-                    }
-                }}
-                drugInfo={medicineInfo}
-            />
-            }
+            {showMedicineEdit && medicineInfo && (
+                /* MedicineEdit Modal */
+                <MedicineEdit
+                    show={showMedicineEdit}
+                    onClose={(r) => {
+                        setShowMedicineEdit(false);
+                        if (r) {
+                            saveOtcMedicine(r);
+                        }
+                    }}
+                    drugInfo={medicineInfo}
+                />
+            )}
 
-            {medicineInfo && showDeleteMedicine &&
-            <Confirm.Modal
-                size="lg"
-                show={showDeleteMedicine}
-                buttonvariant="danger"
-                onSelect={(a) => {
-                    setShowDeleteMedicine(false);
-                    if (a) {
-                        mm.deleteMedicine(medicineInfo?.Id as number).then(d => {
-                            if (d) {
-                                mm.loadOtcList().then(ol => {
-                                    setOtcList(ol)
-                                })
-                            } else {
-                                setErrorDetails('Unable to Delete OTC medicine. Id: ' + medicineInfo.Id);
-                            }
-                        })
-                    }
-                }}
-            >
-                <Confirm.Header>
-                    <Confirm.Title>
-                        {"Delete " + medicineInfo.Drug}
-                    </Confirm.Title>
-                </Confirm.Header>
-                <Confirm.Body>
-                    <Alert
-                        variant="danger"
-                        style={{textAlign: "center"}}
-                    >
+            {medicineInfo && showDeleteMedicine && (
+                <Confirm.Modal
+                    size="lg"
+                    show={showDeleteMedicine}
+                    buttonvariant="danger"
+                    onSelect={(a) => {
+                        setShowDeleteMedicine(false);
+                        if (a) {
+                            mm.deleteMedicine(medicineInfo?.Id as number).then((d) => {
+                                if (d) {
+                                    mm.loadOtcList().then((ol) => setOtcList(ol));
+                                } else {
+                                    setErrorDetails('Unable to Delete OTC medicine. Id: ' + medicineInfo.Id);
+                                }
+                            });
+                        }
+                    }}
+                >
+                    <Confirm.Header>
+                        <Confirm.Title>{'Delete ' + medicineInfo.Drug}</Confirm.Title>
+                    </Confirm.Header>
+                    <Confirm.Body>
+                        <Alert variant="danger" style={{textAlign: 'center'}}>
                             <span>
                                 This will delete the OTC medicine <b>{medicineInfo.Drug}</b> for <i>ALL</i> residents
                             </span>
-                        <span> and <b>ALL</b> history for this drug!</span>
-                    </Alert>
-                    <Alert variant="warning">
-                        Are you sure?
-                    </Alert>
-                </Confirm.Body>
-            </Confirm.Modal>
-            }
+                            <span>
+                                {' '}
+                                and <b>ALL</b> history for this drug!
+                            </span>
+                        </Alert>
+                        <Alert variant="warning">Are you sure?</Alert>
+                    </Confirm.Body>
+                </Confirm.Modal>
+            )}
         </>
     );
-}
+};
 
 export default ManageOtcPage;

--- a/src/managers/MedicineManager.ts
+++ b/src/managers/MedicineManager.ts
@@ -1,24 +1,25 @@
-import {IMedHistoryProvider} from "providers/MedHistoryProvider";
-import {DeleteResponse, IMedicineProvider} from "providers/MedicineProvider";
-import {IPillboxItemProvider} from "providers/PillboxItemProvider";
-import {IPillboxProvider} from "providers/PillboxProvider";
-import {DrugLogRecord, MedicineRecord, PillboxItemRecord, PillboxRecord} from "types/RecordTypes";
-import {asyncWrapper} from "utility/common";
+import {IMedHistoryProvider} from 'providers/MedHistoryProvider';
+import {DeleteResponse, IMedicineProvider} from 'providers/MedicineProvider';
+import {IPillboxItemProvider} from 'providers/PillboxItemProvider';
+import {IPillboxProvider} from 'providers/PillboxProvider';
+import {DrugLogRecord, MedicineRecord, PillboxItemRecord, PillboxRecord} from 'types/RecordTypes';
+import {asyncWrapper} from 'utility/common';
 
 export interface IMedicineManager {
-    deleteDrugLog: (drugLogId: number) => Promise<boolean>
-    deleteMedicine: (medicineId: number) => Promise<boolean>
-    deletePillbox: (pillboxId: number) => Promise<boolean>
-    deletePillboxItem: (pillboxItemId: number) => Promise<boolean>
-    loadDrugLog: (residentId: number, days?: number) => Promise<DrugLogRecord[]>
-    loadMedicineList: (residentId: number) => Promise<MedicineRecord[]>
-    loadPillboxList: (residentId: number) => Promise<PillboxRecord[]>
-    loadPillboxItemList: (clientId: number) => Promise<PillboxItemRecord[]>
-    loadOtcList: () => Promise<MedicineRecord[]>
-    updateDrugLog: (drugLogRecord: DrugLogRecord) => Promise<DrugLogRecord>
-    updateMedicine: (medicine: MedicineRecord) => Promise<MedicineRecord>
-    updatePillbox: (pillbox: PillboxRecord) => Promise<PillboxRecord>
-    updatePillboxItem: (pillboxItemRecord: PillboxItemRecord) => Promise<PillboxItemRecord>
+    deleteDrugLog: (drugLogId: number) => Promise<boolean>;
+    deleteMedicine: (medicineId: number) => Promise<boolean>;
+    deletePillbox: (pillboxId: number) => Promise<boolean>;
+    deletePillboxItem: (pillboxItemId: number) => Promise<boolean>;
+    loadDrugLog: (residentId: number, days?: number) => Promise<DrugLogRecord[]>;
+    loadMedicineList: (residentId: number) => Promise<MedicineRecord[]>;
+    loadPillboxList: (residentId: number) => Promise<PillboxRecord[]>;
+    loadPillboxItemList: (clientId: number) => Promise<PillboxItemRecord[]>;
+    loadOtcList: () => Promise<MedicineRecord[]>;
+    logPillbox: (pillboxId: number) => Promise<DrugLogRecord[]>;
+    updateDrugLog: (drugLogRecord: DrugLogRecord) => Promise<DrugLogRecord>;
+    updateMedicine: (medicine: MedicineRecord) => Promise<MedicineRecord>;
+    updatePillbox: (pillbox: PillboxRecord) => Promise<PillboxRecord>;
+    updatePillboxItem: (pillboxItemRecord: PillboxItemRecord) => Promise<PillboxItemRecord>;
 }
 
 /**
@@ -39,37 +40,43 @@ const MedicineManager = (
      * @param {number} drugLogId
      */
     const _deleteDrugLog = async (drugLogId: number) => {
-        const [e, r] = await asyncWrapper(medHistoryProvider.delete(drugLogId)) as [unknown, Promise<DeleteResponse>];
-        if (e) throw e; else return (await r).success;
-
-    }
+        const [e, r] = (await asyncWrapper(medHistoryProvider.delete(drugLogId))) as [unknown, Promise<DeleteResponse>];
+        if (e) throw e;
+        else return (await r).success;
+    };
 
     /**
      * Delete a Medicine record given the Id.
      * @param {number} medicineId
      */
     const _deleteMedicine = async (medicineId: number) => {
-        const [e, r] = await asyncWrapper(medicineProvider.delete(medicineId)) as [unknown, Promise<DeleteResponse>];
-        if (e) throw e; else return (await r).success;
-    }
+        const [e, r] = (await asyncWrapper(medicineProvider.delete(medicineId))) as [unknown, Promise<DeleteResponse>];
+        if (e) throw e;
+        else return (await r).success;
+    };
 
     /**
      * Delete a Pillbox record given the Id.
      * @param {number} pillboxId
      */
     const _deletePillbox = async (pillboxId: number) => {
-        const [e, r] = await asyncWrapper(pillboxProvider.delete(pillboxId)) as [unknown, Promise<DeleteResponse>];
-        if (e) throw e; else return (await r).success;
-    }
+        const [e, r] = (await asyncWrapper(pillboxProvider.delete(pillboxId))) as [unknown, Promise<DeleteResponse>];
+        if (e) throw e;
+        else return (await r).success;
+    };
 
     /**
      * Delete a PillboxItem record given the Id.
      * @param {number} pillboxItemId
      */
     const _deletePillboxItem = async (pillboxItemId: number) => {
-        const [e, r] = await asyncWrapper(pillboxProvider.delete(pillboxItemId)) as [unknown, Promise<DeleteResponse>];
-        if (e) throw e; else return (await r).success;
-    }
+        const [e, r] = (await asyncWrapper(pillboxProvider.delete(pillboxItemId))) as [
+            unknown,
+            Promise<DeleteResponse>
+        ];
+        if (e) throw e;
+        else return (await r).success;
+    };
 
     /**
      * Returns all the MedHistory records for the given ResidentId as a promise
@@ -82,7 +89,10 @@ const MedicineManager = (
             const d = new Date();
             d.setDate(d.getDate() - days);
             searchCriteria = {
-                where: [['ResidentId', '=', residentId], ['Updated', '>' , d]],
+                where: [
+                    ['ResidentId', '=', residentId],
+                    ['Updated', '>', d]
+                ],
                 orderBy: [['Created', 'desc']]
             };
         } else {
@@ -91,10 +101,13 @@ const MedicineManager = (
                 orderBy: [['Created', 'desc']]
             };
         }
-        const [e, r] = await
-            asyncWrapper(medHistoryProvider.search(searchCriteria)) as [unknown, Promise<DrugLogRecord[]>];
-        if (e) throw e; else return r;
-    }
+        const [e, r] = (await asyncWrapper(medHistoryProvider.search(searchCriteria))) as [
+            unknown,
+            Promise<DrugLogRecord[]>
+        ];
+        if (e) throw e;
+        else return r;
+    };
 
     /**
      * Returns all the PillboxItem records for the given clientId as a promise
@@ -105,10 +118,13 @@ const MedicineManager = (
             where: [['ResidentId', '=', clientId]],
             orderBy: [['Created', 'desc']]
         };
-        const [e, r] = await
-            asyncWrapper(pillboxItemProvider.search(searchCriteria)) as [unknown, Promise<PillboxItemRecord[]>];
-        if (e) throw e; else return r;
-    }
+        const [e, r] = (await asyncWrapper(pillboxItemProvider.search(searchCriteria))) as [
+            unknown,
+            Promise<PillboxItemRecord[]>
+        ];
+        if (e) throw e;
+        else return r;
+    };
 
     /**
      * Returns all the Medicine records for the given ResidentId as a promise
@@ -119,10 +135,13 @@ const MedicineManager = (
             where: [['ResidentId', '=', residentId]],
             orderBy: [['Drug', 'asc']]
         };
-        const [e, r] = await
-            asyncWrapper(medicineProvider.search(searchCriteria)) as [unknown,  Promise<MedicineRecord[]>];
-        if (e) throw e; else return r;
-    }
+        const [e, r] = (await asyncWrapper(medicineProvider.search(searchCriteria))) as [
+            unknown,
+            Promise<MedicineRecord[]>
+        ];
+        if (e) throw e;
+        else return r;
+    };
 
     /**
      * Returns all the Pillbox records for the given ResidentId as a promise
@@ -133,10 +152,13 @@ const MedicineManager = (
             where: [['ResidentId', '=', residentId]],
             orderBy: [['Name', 'asc']]
         };
-        const [e, r] = await
-            asyncWrapper(pillboxProvider.search(searchCriteria)) as [unknown, Promise<PillboxRecord[]>];
-        if (e) throw e; else return r;
-    }
+        const [e, r] = (await asyncWrapper(pillboxProvider.search(searchCriteria))) as [
+            unknown,
+            Promise<PillboxRecord[]>
+        ];
+        if (e) throw e;
+        else return r;
+    };
 
     /**
      * Returns all the OTC medicines as a promise
@@ -144,49 +166,64 @@ const MedicineManager = (
     const _loadOtcList = async () => {
         const searchCriteria = {
             where: [['OTC', '=', true]],
-            orderBy: [['Drug','asc']]
+            orderBy: [['Drug', 'asc']]
         };
-        const [e, r] = await
-            asyncWrapper(medicineProvider.search(searchCriteria)) as [unknown,  Promise<MedicineRecord[]>];
-        if (e) throw e; else return r;
-    }
+        const [e, r] = (await asyncWrapper(medicineProvider.search(searchCriteria))) as [
+            unknown,
+            Promise<MedicineRecord[]>
+        ];
+        if (e) throw e;
+        else return r;
+    };
 
     /**
      * Add or update a MedHistory record
      * @param {DrugLogRecord} drugLogInfo
      */
     const _updateDrugLog = async (drugLogInfo: DrugLogRecord) => {
-        const [e, r] = await asyncWrapper(medHistoryProvider.post(drugLogInfo)) as [unknown, Promise<DrugLogRecord>]
-        if (e) throw e; else return r;
-    }
+        const [e, r] = (await asyncWrapper(medHistoryProvider.post(drugLogInfo))) as [unknown, Promise<DrugLogRecord>];
+        if (e) throw e;
+        else return r;
+    };
 
     /**
      * Adds or updates a Medicine record.
      * @param {MedicineRecord} drugInfo
      */
     const _updateMedicine = async (drugInfo: MedicineRecord) => {
-        const [e, r] = await asyncWrapper(medicineProvider.post(drugInfo)) as [unknown, Promise<MedicineRecord>];
-        if (e) throw e; else return r;
-    }
+        const [e, r] = (await asyncWrapper(medicineProvider.post(drugInfo))) as [unknown, Promise<MedicineRecord>];
+        if (e) throw e;
+        else return r;
+    };
 
     /**
      * Adds or updates a Pillbox record.
      * @param {PillboxRecord} pillInfo
      */
     const _updatePillbox = async (pillInfo: PillboxRecord) => {
-        const [e, r] = await asyncWrapper(pillboxProvider.post(pillInfo)) as [unknown, Promise<PillboxRecord>];
-        if (e) throw e; else return r;
-    }
+        const [e, r] = (await asyncWrapper(pillboxProvider.post(pillInfo))) as [unknown, Promise<PillboxRecord>];
+        if (e) throw e;
+        else return r;
+    };
 
     /**
      * Adds or updates a PillboxItem record.
      * @param {PillboxItemRecord} pillboxItemInfo
      */
     const _updatePillboxItem = async (pillboxItemInfo: PillboxItemRecord) => {
-        const [e, r] = await
-            asyncWrapper(pillboxItemProvider.post(pillboxItemInfo)) as [unknown, Promise<PillboxItemRecord>];
-        if (e) throw e; else return r;
-    }
+        const [e, r] = (await asyncWrapper(pillboxItemProvider.post(pillboxItemInfo))) as [
+            unknown,
+            Promise<PillboxItemRecord>
+        ];
+        if (e) throw e;
+        else return r;
+    };
+
+    const _logPillbox = async (pillboxId: number) => {
+        const [e, r] = (await asyncWrapper(pillboxProvider.log(pillboxId))) as [unknown, Promise<DrugLogRecord[]>];
+        if (e) throw e;
+        else return r;
+    };
 
     return {
         deleteDrugLog: async (drugLogId: number): Promise<boolean> => {
@@ -227,8 +264,11 @@ const MedicineManager = (
         },
         updatePillboxItem: async (pillboxItem: PillboxItemRecord): Promise<PillboxItemRecord> => {
             return await _updatePillboxItem(pillboxItem);
+        },
+        logPillbox: async (pillboxId: number): Promise<DrugLogRecord[]> => {
+            return await _logPillbox(pillboxId);
         }
-    }
-}
+    };
+};
 
 export default MedicineManager;

--- a/src/providers/PillboxProvider.ts
+++ b/src/providers/PillboxProvider.ts
@@ -1,19 +1,26 @@
-import Frak from "frak/lib/components/Frak";
-import {PillboxRecord} from 'types/RecordTypes';
+import Frak from 'frak/lib/components/Frak';
+import {DrugLogRecord, PillboxRecord} from 'types/RecordTypes';
 
 export interface IPillboxProvider {
-    setApiKey: (apiKey: string) => void
-    search: (options: object) => Promise<PillboxRecord[]>
-    read: (id: number | string) => Promise<PillboxRecord>
-    post: (drugInfo: PillboxRecord) => Promise<PillboxRecord>
-    delete: (drugId: string | number) => Promise<DeleteResponse>
+    setApiKey: (apiKey: string) => void;
+    search: (options: object) => Promise<PillboxRecord[]>;
+    read: (id: number | string) => Promise<PillboxRecord>;
+    post: (drugInfo: PillboxRecord) => Promise<PillboxRecord>;
+    delete: (drugId: string | number) => Promise<DeleteResponse>;
+    log: (pillboxId: number) => Promise<DrugLogRecord[]>;
 }
 
-type DeleteResponse = { success: boolean };
+type DeleteResponse = {success: boolean};
 type RecordResponse = {
     data: PillboxRecord[] | PillboxRecord;
     status: number;
     success: boolean;
+};
+
+type LogResponse = {
+    success: boolean;
+    status: number;
+    data: DrugLogRecord[];
 };
 
 /**
@@ -93,6 +100,25 @@ const PillboxProvider = (baseUrl: string): IPillboxProvider => {
         },
 
         /**
+         * Post interface
+         * @returns {Promise<PillboxRecord>}
+         * @param pillboxId
+         */
+        log: async (pillboxId: number): Promise<DrugLogRecord[]> => {
+            const uri = _baseUrl + 'pillbox/log?api_key=' + _apiKey;
+            try {
+                const response = await _frak.post<LogResponse>(uri, {pillbox_id: pillboxId});
+                if (response.success) {
+                    return response.data;
+                } else {
+                    throw response;
+                }
+            } catch (err) {
+                throw err;
+            }
+        },
+
+        /**
          * Delete interface
          * @param {string | number} drugId
          * @returns {Promise<DeleteResponse>}
@@ -110,7 +136,7 @@ const PillboxProvider = (baseUrl: string): IPillboxProvider => {
                 throw err;
             }
         }
-    }
-}
+    };
+};
 
 export default PillboxProvider;


### PR DESCRIPTION
- Grids now show strikethrough for medicine that has been deactivated
- `handleLogPillbox()` in MedicinePage now uses a server side process to log drugs. This closes #199
- The process to build out the medicine list has been moved from MedListGroup to MedicinePage. This Closes #196
- When a medicine is set as inactive the affected medicine in PillboxItemsList is deleted
- ManageOtcPage updated and prettified
- `logPillbox()` added to MedicineManager.ts called via PillboxProvider.ts

rxchart-app must be updated for this to be implemented