### PR TITLE
Pillbox components use `gridLists` prop to reduce prop drilling

### DIFF
--- a/src/components/Pages/Grids/DrugLogGrid.tsx
+++ b/src/components/Pages/Grids/DrugLogGrid.tsx
@@ -12,17 +12,21 @@ import {
     isToday
 } from 'utility/common';
 
+export interface IGridLists {
+    drugLogList?: DrugLogRecord[];
+    medicineList?: MedicineRecord[];
+    pillboxList?: PillboxRecord[];
+    pillboxItemList?: PillboxItemRecord[];
+}
+
 interface IProps extends TableProps {
     checkoutOnly?: boolean;
     columns: string[];
     condensed?: string;
     drugId?: number | null;
-    drugLog?: DrugLogRecord[];
-    medicineList?: MedicineRecord[];
     onDelete?: (r: DrugLogRecord) => void;
     onEdit?: (r: DrugLogRecord) => void;
-    pillboxList?: PillboxRecord[];
-    pillboxItemList?: PillboxItemRecord[];
+    gridLists: IGridLists;
     onPillClick?: (n: number) => void;
 }
 
@@ -32,20 +36,15 @@ interface IProps extends TableProps {
  * @returns {JSX.Element}
  */
 const DrugLogGrid = (props: IProps): JSX.Element => {
-    const {
-        columns,
-        condensed = 'false',
-        drugId,
-        drugLog = [],
-        medicineList = [],
-        onDelete,
-        onEdit,
-        pillboxList = [] as PillboxRecord[],
-        pillboxItemList = [] as PillboxItemRecord[],
-        onPillClick
-    } = props;
+    const {columns, condensed = 'false', drugId, onDelete, onEdit, gridLists, onPillClick} = props;
 
-    const filteredDrugs = drugId ? drugLog.filter((drug) => drug && drug.MedicineId === drugId) : drugLog;
+    // Deconstruct the gridLists
+    const drugLogList = gridLists.drugLogList || ([] as DrugLogRecord[]);
+    const medicineList = gridLists.medicineList || ([] as MedicineRecord[]);
+    const pillboxList = gridLists.pillboxList || ([] as PillboxRecord[]);
+    const pillboxItemList = gridLists.pillboxItemList || ([] as PillboxItemRecord[]);
+
+    const filteredDrugs = drugId ? drugLogList.filter((drug) => drug && drug.MedicineId === drugId) : drugLogList;
 
     /**
      * Returns the value of the drug column for the given drugId
@@ -249,7 +248,7 @@ const DrugLogGrid = (props: IProps): JSX.Element => {
                     {onDelete && <th></th>}
                 </tr>
             </thead>
-            <tbody>{drugLog && drugLog.length && filteredDrugs ? filteredDrugs.map(DrugRow) : <></>}</tbody>
+            <tbody>{drugLogList && drugLogList.length && filteredDrugs ? filteredDrugs.map(DrugRow) : <></>}</tbody>
         </Table>
     );
 };

--- a/src/components/Pages/Grids/PillboxLogGrid.tsx
+++ b/src/components/Pages/Grids/PillboxLogGrid.tsx
@@ -1,10 +1,14 @@
-import {TPillboxLog} from 'components/Pages/MedicinePage';
+import {IGridLists} from 'components/Pages/Grids/DrugLogGrid';
+import PillPopover from 'components/Pages/Grids/PillPopover';
+import {TPillboxMedLog} from 'components/Pages/MedicinePage';
 import Table from 'react-bootstrap/Table';
 import React from 'reactn';
+import {PillboxItemRecord, PillboxRecord} from 'types/RecordTypes';
 import {BsColor, randomString} from 'utility/common';
 
 interface IProps {
-    pillboxLogList: TPillboxLog[];
+    gridLists: IGridLists;
+    pillboxMedLogList: TPillboxMedLog[];
 }
 
 /**
@@ -12,8 +16,10 @@ interface IProps {
  * @param {IProps} props The props for this component
  */
 const PillboxLogGrid = (props: IProps) => {
-    const pillboxLogList = props.pillboxLogList;
-    const key = randomString();
+    const pillboxMedLogList = props.pillboxMedLogList;
+    const gridLists = props.gridLists;
+    const pillboxList = gridLists.pillboxList || ([] as PillboxRecord[]);
+    const pillboxItemList = gridLists.pillboxItemList || ([] as PillboxItemRecord[]);
 
     return (
         <Table style={{wordWrap: 'break-word'}} bordered size="sm" striped>
@@ -26,7 +32,7 @@ const PillboxLogGrid = (props: IProps) => {
                 <th>Time</th>
             </tr>
             <tbody>
-                {pillboxLogList.map((log) => {
+                {pillboxMedLogList.map((log) => {
                     const updated = log.Updated
                         ? new Date(log.Updated).toLocaleString('en-US', {
                               hour: '2-digit',
@@ -34,15 +40,28 @@ const PillboxLogGrid = (props: IProps) => {
                           })
                         : '';
                     const strikeThrough = log.Active ? undefined : 'line-through';
+                    const key = log.PillboxItemId || randomString();
+
                     return (
-                        <tr key={`pillbox-log-grid-${key}`} style={{fontWeight: 'bold', color: BsColor.success}}>
+                        <tr
+                            id={key.toString()}
+                            key={`pillbox-log-grid-${key}`}
+                            style={{fontWeight: 'bold', color: BsColor.success}}
+                        >
                             <td>
                                 <span style={{textDecoration: strikeThrough}}>
                                     {log.Drug} {log.Strength}
                                 </span>
                             </td>
                             <td>
-                                {'💊 '} {log.Notes}
+                                <PillPopover
+                                    id={log.PillboxItemId as number}
+                                    pillboxItemId={log.PillboxItemId as number}
+                                    pillboxItemList={pillboxItemList}
+                                    pillboxList={pillboxList}
+                                    onPillClick={(n) => n + 1}
+                                />{' '}
+                                {log.Notes}
                             </td>
                             <td>{updated}</td>
                         </tr>

--- a/src/components/Pages/ListGroups/PillboxListGroup.tsx
+++ b/src/components/Pages/ListGroups/PillboxListGroup.tsx
@@ -1,6 +1,7 @@
+import {IGridLists} from 'components/Pages/Grids/DrugLogGrid';
 import PillboxLogGrid from 'components/Pages/Grids/PillboxLogGrid';
 import DisabledSpinner from 'components/Pages/ListGroups/DisabledSpinner';
-import {TPillboxLog} from 'components/Pages/MedicinePage';
+import {TPillboxMedLog} from 'components/Pages/MedicinePage';
 import Alert from 'react-bootstrap/Alert';
 import Badge from 'react-bootstrap/Badge';
 import Button from 'react-bootstrap/Button';
@@ -18,16 +19,13 @@ import PillboxEdit from '../Modals/PillboxEdit';
 
 interface IProps {
     activePillbox: PillboxRecord | null;
-    clientId: number;
     disabled?: boolean;
     logPillbox: () => void;
-    medicineList: MedicineRecord[];
     onDelete: (id: number) => void;
     onEdit: (pb: PillboxRecord) => void;
     onSelect: (n: number) => void;
-    pillboxItemList: PillboxItemRecord[];
-    pillboxList: PillboxRecord[];
-    pillboxLogList: TPillboxLog[];
+    gridLists: IGridLists;
+    pillboxMedLogList: TPillboxMedLog[];
 }
 
 interface IPillboxLineItem {
@@ -43,17 +41,18 @@ interface IPillboxLineItem {
 const PillboxListGroup = (props: IProps) => {
     const {
         activePillbox,
-        clientId,
         disabled = false,
         logPillbox,
-        medicineList = [],
         onDelete,
         onEdit,
         onSelect,
-        pillboxItemList,
-        pillboxList,
-        pillboxLogList
+        gridLists,
+        pillboxMedLogList
     } = props;
+    const clientId = activePillbox?.ResidentId;
+    const pillboxList = gridLists.pillboxList || ([] as PillboxRecord[]);
+    const pillboxItemList = gridLists.pillboxItemList || ([] as PillboxItemRecord[]);
+    const medicineList = gridLists.medicineList || ([] as MedicineRecord[]);
 
     // If there is at least one pillbox (but no active pillbox) then force the first pillbox as the active pillbox
     if (pillboxList.length > 0 && !activePillbox) onSelect(pillboxList[0].Id as number);
@@ -62,7 +61,7 @@ const PillboxListGroup = (props: IProps) => {
     const [showPillboxDeleteConfirm, setShowPillboxDeleteConfirm] = useState(false);
     const [pillboxInfo, setPillboxInfo] = useState<PillboxRecord | null>(null);
 
-    const firstLoggedPillbox = pillboxLogList.find((p) => p.Updated)?.Updated;
+    const firstLoggedPillbox = pillboxMedLogList.find((p) => p.Updated)?.Updated;
     const logTime = firstLoggedPillbox
         ? new Date(firstLoggedPillbox).toLocaleString('en-US', {
               hour: '2-digit',
@@ -106,6 +105,8 @@ const PillboxListGroup = (props: IProps) => {
         paddingBottom: '0.20rem',
         paddingLeft: '1.25rem'
     };
+
+    if (!clientId) return null;
 
     /**
      * Pillbox RadioButton component
@@ -296,9 +297,9 @@ const PillboxListGroup = (props: IProps) => {
                     </Card>
                 )}
 
-                {pillboxLogList.length > 0 && (
+                {pillboxMedLogList.length > 0 && (
                     <ListGroup.Item style={listboxItemStyle}>
-                        <PillboxLogGrid pillboxLogList={pillboxLogList} />
+                        <PillboxLogGrid gridLists={gridLists} pillboxMedLogList={pillboxMedLogList} />
                     </ListGroup.Item>
                 )}
 


### PR DESCRIPTION
- DrugLogGrid uses `gridLists` prop
- PillboxListGroup uses `gridLists` prop
- MedicinePage uses `gridLists`

Closes #209
Closes #207