### PR TITLE
UI :lipstick:  change for Manage Rx and Manage OTC

### DIFF
--- a/src/components/Pages/Grids/DrugLogGrid.tsx
+++ b/src/components/Pages/Grids/DrugLogGrid.tsx
@@ -73,6 +73,7 @@ const DrugLogGrid = (props: IProps): JSX.Element => {
         // Figure out medicine field values
         const isOtc = drugColumnLookup(drug.MedicineId, 'OTC');
         let drugName = drugColumnLookup(drug.MedicineId, 'Drug') as string | null;
+        const active = drugColumnLookup(drug.MedicineId, 'Active');
         const medicineNotes = drugColumnLookup(drug.MedicineId, 'Notes') as string | null;
         const medicineDirections = drugColumnLookup(drug.MedicineId, 'Directions');
         const drugDetails = (
@@ -93,7 +94,11 @@ const DrugLogGrid = (props: IProps): JSX.Element => {
         const fontWeight = isToday(updatedDate) ? 'bold' : undefined;
 
         return (
-            <tr key={'druglog-grid-row-' + drug.Id} id={'druglog-grid-row-' + drug.Id} style={{color: variantColor}}>
+            <tr
+                key={'druglog-grid-row-' + drug.Id}
+                id={'druglog-grid-row-' + drug.Id}
+                style={{color: variantColor, textDecoration: !active ? 'line-through' : undefined}}
+            >
                 {onEdit && (
                     <td style={{textAlign: 'center', verticalAlign: 'middle'}}>
                         <Button

--- a/src/components/Pages/Grids/ManageDrugGrid.tsx
+++ b/src/components/Pages/Grids/ManageDrugGrid.tsx
@@ -1,5 +1,6 @@
 import Badge from 'react-bootstrap/Badge';
 import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
 import Table from 'react-bootstrap/Table';
 import React from 'reactn';
 import {MedicineRecord} from 'types/RecordTypes';
@@ -69,12 +70,11 @@ const ManageDrugGrid = (props: IProps): JSX.Element => {
                     <Button
                         size="sm"
                         id={'manage-drug-grid-delete-btn' + drug.Id}
-                        variant={'outline-warning'}
+                        variant={'outline-light'}
                         onClick={() => onDelete(drug)}
-                        disabled={!drug.Active}
                     >
                         <span role="img" aria-label="delete">
-                            {'🚫'}
+                            <Form.Check style={{transform: 'scale(2)'}} checked={drug.Active} name="Active" />
                         </span>
                     </Button>
                 </td>
@@ -93,7 +93,7 @@ const ManageDrugGrid = (props: IProps): JSX.Element => {
                     <th>Directions</th>
                     <th>Notes</th>
                     <th>Barcode</th>
-                    <th style={{textAlign: 'center', verticalAlign: 'middle'}}>Deactivate</th>
+                    <th style={{textAlign: 'center', verticalAlign: 'middle'}}>Active</th>
                 </tr>
             </thead>
             <tbody>{medicineList.map(TableRow)}</tbody>

--- a/src/components/Pages/Grids/ManageOtcGrid.tsx
+++ b/src/components/Pages/Grids/ManageOtcGrid.tsx
@@ -1,4 +1,5 @@
 import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
 import Table from 'react-bootstrap/Table';
 import React from 'reactn';
 import {MedicineRecord} from 'types/RecordTypes';
@@ -17,35 +18,42 @@ interface IProps {
 const ManageOtcGrid = (props: IProps): JSX.Element => {
     const {onDelete, onEdit, otcList} = props;
 
-    const OtcRow = (drug: MedicineRecord) => {
+    const OtcRow = (medicineRecord: MedicineRecord) => {
         return (
-            <tr key={drug.Id} id={'med-detail-grid-row-' + drug.Id}>
+            <tr
+                key={medicineRecord.Id}
+                id={'otc-detail-grid-row-' + medicineRecord.Id}
+                style={{textDecoration: !medicineRecord.Active ? 'line-through' : undefined}}
+            >
                 <td style={{textAlign: 'center', verticalAlign: 'middle'}}>
-                    <Button size="sm" id={'medicine-edit-btn-row' + drug.Id} onClick={() => onEdit(drug)}>
+                    <Button
+                        size="sm"
+                        id={'otc-edit-btn-row' + medicineRecord.Id}
+                        onClick={() => onEdit(medicineRecord)}
+                    >
                         Edit
                     </Button>
                 </td>
 
-                <td style={{verticalAlign: 'middle'}}>{drug.Drug}</td>
+                <td style={{verticalAlign: 'middle'}}>{medicineRecord.Drug}</td>
 
-                <td style={{verticalAlign: 'middle'}}>{drug.OtherNames}</td>
+                <td style={{verticalAlign: 'middle'}}>{medicineRecord.OtherNames}</td>
 
-                <td style={{verticalAlign: 'middle'}}>{drug.Strength}</td>
+                <td style={{verticalAlign: 'middle'}}>{medicineRecord.Strength}</td>
 
-                <td style={{verticalAlign: 'middle'}}>{drug.Directions}</td>
+                <td style={{verticalAlign: 'middle'}}>{medicineRecord.Directions}</td>
 
-                <td style={{verticalAlign: 'middle'}}>{drug.Barcode}</td>
+                <td style={{verticalAlign: 'middle'}}>{medicineRecord.Barcode}</td>
 
                 <td style={{textAlign: 'center', verticalAlign: 'middle'}}>
                     <Button
                         size="sm"
-                        id={'medicine-grid-delete-btn-' + drug.Id}
-                        variant="outline-danger"
-                        onClick={() => onDelete(drug)}
-                        disabled={!drug.Active}
+                        id={'otc-grid-delete-btn-' + medicineRecord.Id}
+                        variant="outline-light"
+                        onClick={() => onDelete(medicineRecord)}
                     >
                         <span role="img" aria-label="delete">
-                            🗑
+                            <Form.Check style={{transform: 'scale(2)'}} checked={medicineRecord.Active} name="Active" />
                         </span>
                     </Button>
                 </td>
@@ -63,7 +71,7 @@ const ManageOtcGrid = (props: IProps): JSX.Element => {
                     <th>Strength</th>
                     <th>Directions</th>
                     <th>Barcode</th>
-                    <th style={{textAlign: 'center', verticalAlign: 'middle'}}>Delete</th>
+                    <th style={{textAlign: 'center', verticalAlign: 'middle'}}>Active</th>
                 </tr>
             </thead>
             <tbody>{otcList.map(OtcRow)}</tbody>

--- a/src/components/Pages/LandingPage.tsx
+++ b/src/components/Pages/LandingPage.tsx
@@ -45,12 +45,6 @@ const LandingPage = () => {
         return <ClientPage activeTabKey={activeTabKey} clientSelected={() => setActiveTabKey('medicine')} />;
     }, [activeTabKey, setActiveTabKey]);
 
-    const manageOtcPage = useMemo(() => {
-        if (activeClient) {
-            return <ManageOtcPage activeTabKey={activeTabKey} clientRecord={activeClient.clientInfo} />;
-        }
-    }, [activeTabKey, activeClient]);
-
     const loginPage = useMemo(() => {
         return <LoginPage activeTabKey={activeTabKey} setActiveTabKey={setActiveTabKey} />;
     }, [activeTabKey, setActiveTabKey]);
@@ -86,7 +80,9 @@ const LandingPage = () => {
                 <Tab.Content>{manageDrugPage}</Tab.Content>
             </Tab>
             <Tab disabled={!apiKey} eventKey="manage-otc" title={<Title activeKey="manage-otc">Manage OTC</Title>}>
-                <Tab.Content>{manageOtcPage}</Tab.Content>
+                <Tab.Content>
+                    <ManageOtcPage activeTabKey={activeTabKey} />
+                </Tab.Content>
             </Tab>
             <Tab disabled={!errorDetails} eventKey="error" title={<Title activeKey="error">Diagnostics</Title>}>
                 <DiagnosticPage error={errorDetails} dismissErrorAlert={() => window.location.reload()} />

--- a/src/components/Pages/ListGroups/OtcListGroup.tsx
+++ b/src/components/Pages/ListGroups/OtcListGroup.tsx
@@ -38,7 +38,7 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
         otcSelected
     } = props;
 
-    const [filteredOtcList, setFilteredOtcList] = useState(otcList);
+    const [filteredOtcList, setFilteredOtcList] = useState(otcList.filter((o) => o.Active));
     const [searchIsValid, setSearchIsValid] = useState<boolean | null>(null);
     const [searchText, setSearchText] = useState('');
     const lastTaken = activeOtc?.Id ? calculateLastTaken(activeOtc.Id, drugLogList) : null;
@@ -53,13 +53,16 @@ const OtcListGroup = (props: IProps): JSX.Element | null => {
                 const barcode = medicineRecord.Barcode ? medicineRecord.Barcode.toLowerCase() : '';
                 const other = medicineRecord.OtherNames ? medicineRecord.OtherNames.toLowerCase() : '';
                 const search = searchText.toLowerCase();
-                return drug.includes(search) || barcode.includes(search) || other.includes(search);
+                return (
+                    medicineRecord.Active &&
+                    (drug.includes(search) || barcode.includes(search) || other.includes(search))
+                );
             });
             setSearchIsValid(filter?.length > 0);
             setFilteredOtcList(filter?.length > 0 ? filter : []);
         } else {
             setSearchIsValid(false);
-            setFilteredOtcList(otcList);
+            setFilteredOtcList(otcList.filter((o) => o.Active));
         }
     }, [otcList, searchText]);
 

--- a/src/components/Pages/ManageDrugPage.tsx
+++ b/src/components/Pages/ManageDrugPage.tsx
@@ -40,9 +40,6 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
     const drugLogList = activeClient ? activeClient.drugLogList : [];
     const pillboxItemList = activeClient ? activeClient.pillboxItemList : [];
     const checkoutList = getCheckoutList(drugLogList);
-    // const [checkoutList] = useState(getCheckoutList(drugLogList));
-    console.log('drugLogList', drugLogList);
-    console.log('checkoutList', checkoutList);
 
     const [showCheckoutAlert, setShowCheckoutAlert] = useState(checkoutList.length > 0);
 
@@ -250,11 +247,7 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
                 <Row className="mt-2 d-print-none">
                     <ManageDrugGrid
                         checkoutList={medicineWithCheckout}
-                        onDelete={(mr) => {
-                            const med = {...mr};
-                            med.Active = false;
-                            saveMedicine(med, clientInfo.Id as number);
-                        }}
+                        onDelete={(mr) => saveMedicine({...mr, Active: !mr.Active}, clientInfo.Id as number)}
                         onEdit={(m) => onEdit(m)}
                         onLogDrug={(d) => handleLogDrug(d)}
                         medicineList={medicineList}

--- a/src/components/Pages/Modals/MedicineEdit.tsx
+++ b/src/components/Pages/Modals/MedicineEdit.tsx
@@ -236,30 +236,27 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
                         </Col>
                     </Form.Group>
 
-                    {!drugInfo.OTC && (
-                        <Form.Group as={Row}>
-                            <Col sm="3">
-                                <Form.Label style={{userSelect: 'none'}}>Active</Form.Label>
-                            </Col>
-                            <Col sm="2">
-                                <Form.Check
-                                    style={{transform: 'scale(2)'}}
-                                    onChange={(e) => handleOnChange(e)}
-                                    checked={drugInfo.Active}
-                                    name="Active"
-                                    tabIndex={-1}
-                                />
-                            </Col>
-                            <Col sm="6">
-                                {!drugInfo.Active && (
-                                    <>
-                                        <span style={{fontWeight: 'bold'}}>{drugInfo.Drug}</span> will not appear in the
-                                        dropdown
-                                    </>
-                                )}
-                            </Col>
-                        </Form.Group>
-                    )}
+                    <Form.Group as={Row}>
+                        <Col sm="3">
+                            <Form.Label style={{userSelect: 'none'}}>Active</Form.Label>
+                        </Col>
+                        <Col sm="2">
+                            <Form.Check
+                                style={{transform: 'scale(2)'}}
+                                onChange={(e) => handleOnChange(e)}
+                                checked={drugInfo.Active}
+                                name="Active"
+                                tabIndex={-1}
+                            />
+                        </Col>
+                        <Col sm="6">
+                            {!drugInfo.Active && (
+                                <>
+                                    <span style={{fontWeight: 'bold'}}>{drugInfo.Drug}</span> is unavailable
+                                </>
+                            )}
+                        </Col>
+                    </Form.Group>
 
                     <Form.Group as={Row} controlId="drug-Directions">
                         <Form.Label column sm="2" style={{userSelect: 'none'}}>


### PR DESCRIPTION
- OTC meds that are not active appear as strikethrough for log history
- Both OTC and non-OTC meds grids have an Active column which is now a checkbox that can be toggled to activate and deactivate the medication
- Fixed a bug :bug: where the Memoized ManageOtcPage wasn't rendering (removed the memoization)
- Removed unnecessary props from ManageOtcPage
- MedicineEdit allows for Active editing for both OTC and non-OTC meds
- OtcListGroup updated to filter out `!medicationList.Active`
- Removed the Delete confirmation modal from ManageOtcPage

Unrelated:
- Removed `console.log()`'s left over from the previous commit

Closes #224
Closes #225