### PR TITLE
Allow Medication to be Deleted :bomb:

### DIFF
--- a/src/components/Pages/Modals/DeleteMedicineModal.tsx
+++ b/src/components/Pages/Modals/DeleteMedicineModal.tsx
@@ -1,0 +1,55 @@
+import Confirm from 'components/Pages/Modals/Confirm';
+import Alert from 'react-bootstrap/Alert';
+import React from 'reactn';
+import {MedicineRecord} from 'types/RecordTypes';
+import {BsColor} from 'utility/common';
+
+interface IProps {
+    medicine: MedicineRecord;
+    onSelect: (n: number) => void;
+    show: boolean;
+}
+
+/**
+ * Delete Confirmation Modal
+ * @param {IProps} props The props for the component
+ */
+const DeleteMedicineModal = (props: IProps) => {
+    const {medicine, onSelect, show} = props;
+
+    // If no medicine record then do not render
+    if (!medicine) return null;
+
+    return (
+        <Confirm.Modal
+            onSelect={(a) => onSelect(a ? (medicine.Id as number) : 0)}
+            size="lg"
+            show={show}
+            yesButtonProps={{variant: 'danger'}}
+            yesButtonContent={`Destroy ${medicine.Drug}`}
+        >
+            <Confirm.Header>
+                <Confirm.Title>
+                    <h3>
+                        <span style={{color: BsColor.red}}>Delete</span>{' '}
+                        <span style={{color: BsColor.blue}}>
+                            <b>{medicine.Drug} </b>
+                        </span>
+                        {medicine.Strength}
+                    </h3>
+                </Confirm.Title>
+            </Confirm.Header>
+            <Confirm.Body>
+                <Alert variant="danger">
+                    This will <b>permanently</b> delete{' '}
+                    <span style={{color: BsColor.blue}}>
+                        <b>{medicine.Drug}</b>
+                    </span>
+                </Alert>
+                <b style={{color: 'red'}}>Are you sure?</b>
+            </Confirm.Body>
+        </Confirm.Modal>
+    );
+};
+
+export default DeleteMedicineModal;


### PR DESCRIPTION
- MedicineEdit takes an `allowDelete` prop
- ManageDrugPage and MedicinePage will set the `allowDelete` prop on the MedicineEdit modal if the medication hasn't been logged in the past five days
- - Added a DeleteMedicineModal component that will show when the user has clicked the Delete button in the MedicineEdit modal

Unrelated:

- Cleaned :broom: up the code in MedicinieEdit and a bit in the other two components

Closes #198