### PR TITLE
Modal Improvements :sparkle: 

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "export NODE_OPTIONS=\"--max-old-space-size=1024\" && react-scripts build",
     "test": "react-scripts test",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
-    "lint": "tslint -p tsconfig.json"
+    "lint": "eslint src"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/components/Pages/ListGroups/PillboxListGroup.tsx
+++ b/src/components/Pages/ListGroups/PillboxListGroup.tsx
@@ -19,21 +19,21 @@ import PillboxEdit from '../Modals/PillboxEdit';
 
 interface IProps {
     activePillbox: PillboxRecord | null;
-    disabled?: boolean;
     clientRecord: ClientRecord;
+    disabled?: boolean;
+    gridLists: IGridLists;
     logPillbox: () => void;
     onDelete: (id: number) => void;
     onEdit: (pb: PillboxRecord) => void;
     onSelect: (n: number) => void;
-    gridLists: IGridLists;
     pillboxMedLogList: TPillboxMedLog[];
 }
 
 interface IPillboxLineItem {
-    Id: number | null;
     Drug: string;
-    Strength: string;
+    Id: number | null;
     Qty: number;
+    Strength: string;
 }
 
 /**
@@ -45,19 +45,15 @@ const PillboxListGroup = (props: IProps) => {
         activePillbox,
         clientRecord,
         disabled = false,
+        gridLists,
         logPillbox,
         onDelete,
         onEdit,
         onSelect,
-        gridLists,
         pillboxMedLogList
     } = props;
-    const clientId = activePillbox?.ResidentId;
-    const {pillboxList, pillboxItemList, medicineList} = deconstructGridLists(gridLists);
-    const [showAlert, setShowAlert] = useState(false);
-    const [showPillboxDeleteConfirm, setShowPillboxDeleteConfirm] = useState(false);
-    const [pillboxInfo, setPillboxInfo] = useState<PillboxRecord | null>(null);
 
+    const {pillboxList, pillboxItemList, medicineList} = deconstructGridLists(gridLists);
     const firstLoggedPillbox = pillboxMedLogList.find((p) => p.Updated)?.Updated;
     const logTime = firstLoggedPillbox
         ? new Date(firstLoggedPillbox).toLocaleString('en-US', {
@@ -66,18 +62,19 @@ const PillboxListGroup = (props: IProps) => {
               hour12: true
           } as Intl.DateTimeFormatOptions)
         : null;
-
-    // If there are pillboxes but not an activePillbox then set the activePillbox via the onSelect cb
-    useEffect(() => {
-        if (pillboxList.length > 0 && !activePillbox) {
-            onSelect(pillboxList[0].Id as number);
-        }
-    }, [pillboxList, activePillbox, onSelect]);
-
-    // When the activePillbox has already been logged today then setShowAlert to true
+    const [showAlert, setShowAlert] = useState(false);
     useEffect(() => {
         setShowAlert(logTime !== null);
     }, [activePillbox, logTime]);
+
+    const [showPillboxDeleteConfirm, setShowPillboxDeleteConfirm] = useState(false);
+    const [pillboxInfo, setPillboxInfo] = useState<PillboxRecord | null>(null);
+    const clientId = clientRecord.Id;
+
+    // If there are pillboxes but not an activePillbox then set the activePillbox via the onSelect cb
+    useEffect(() => {
+        if (pillboxList.length > 0 && !activePillbox) onSelect(pillboxList[0].Id as number);
+    }, [pillboxList, activePillbox, onSelect]);
 
     /**
      * Return an array of PillboxItemRecord[] where the Quantity is > 0
@@ -109,8 +106,6 @@ const PillboxListGroup = (props: IProps) => {
         paddingBottom: '0.20rem',
         paddingLeft: '1.25rem'
     };
-
-    if (!clientId) return null;
 
     /**
      * Pillbox RadioButton component
@@ -323,17 +318,15 @@ const PillboxListGroup = (props: IProps) => {
                 )}
             </ListGroup>
 
-            {pillboxInfo && (
-                <PillboxEdit
-                    onClose={(r) => {
-                        setPillboxInfo(null);
-                        if (r) onEdit(r);
-                    }}
-                    clientRecord={clientRecord}
-                    pillboxInfo={pillboxInfo}
-                    show={true}
-                />
-            )}
+            <PillboxEdit
+                onClose={(r) => {
+                    setPillboxInfo(null);
+                    if (r) onEdit(r);
+                }}
+                clientRecord={clientRecord}
+                pillboxInfo={pillboxInfo as PillboxRecord}
+                show={pillboxInfo !== null}
+            />
 
             <Confirm.Modal
                 centered

--- a/src/components/Pages/ManageDrugPage.tsx
+++ b/src/components/Pages/ManageDrugPage.tsx
@@ -306,18 +306,16 @@ const ManageDrugPage = (props: IProps): JSX.Element | null => {
                 drugInfo={medicineInfo as MedicineRecord}
             />
 
-            {showCheckoutModal && clientInfo.Id && (
-                <DrugLogEdit
-                    drugName={drugName(showCheckoutModal.MedicineId) || '[unknown]'}
-                    drugLogInfo={showCheckoutModal}
-                    onClose={(dl) => {
-                        setShowCheckoutModal(null);
-                        if (dl) saveDrugLog([dl], clientInfo.Id as number).then((t) => setToast(t));
-                    }}
-                    onHide={() => setShowCheckoutModal(null)}
-                    show={true}
-                />
-            )}
+            <DrugLogEdit
+                drugLogInfo={showCheckoutModal as DrugLogRecord}
+                drugName={drugName(showCheckoutModal?.MedicineId as number) || '[unknown]'}
+                onClose={(dl) => {
+                    setShowCheckoutModal(null);
+                    if (dl) saveDrugLog([dl], clientInfo.Id as number).then((t) => setToast(t));
+                }}
+                onHide={() => setShowCheckoutModal(null)}
+                show={clientInfo.Id !== null && showCheckoutModal !== null}
+            />
 
             <DrugLogToast
                 toast={toast as DrugLogRecord[]}

--- a/src/components/Pages/ManageOtcPage.tsx
+++ b/src/components/Pages/ManageOtcPage.tsx
@@ -121,12 +121,12 @@ const ManageOtcPage = (props: IProps): JSX.Element | null => {
             </Row>
 
             <MedicineEdit
-                show={showMedicineEdit}
+                drugInfo={medicineInfo as MedicineRecord}
                 onClose={(r) => {
                     setShowMedicineEdit(false);
                     if (r) saveOtcMedicine(r).then((m) => setSearchText(m.Active ? m.Drug : ''));
                 }}
-                drugInfo={medicineInfo as MedicineRecord}
+                show={showMedicineEdit}
             />
         </>
     );

--- a/src/components/Pages/MedicinePage.tsx
+++ b/src/components/Pages/MedicinePage.tsx
@@ -675,8 +675,8 @@ const MedicinePage = (props: IProps): JSX.Element | null => {
 
             <MedicineEdit
                 allowDelete={!drugLogList.find((d) => d.MedicineId === showMedicineEdit?.Id)}
+                drugInfo={showMedicineEdit as MedicineRecord}
                 fullName={clientFullName(activeClient.clientInfo)}
-                show={showMedicineEdit !== null}
                 onClose={(r) => {
                     setShowMedicineEdit(null);
                     if (r) {
@@ -690,22 +690,20 @@ const MedicinePage = (props: IProps): JSX.Element | null => {
                         }
                     }
                 }}
-                drugInfo={showMedicineEdit as MedicineRecord}
+                show={showMedicineEdit !== null}
             />
 
-            {showDrugLog && (
-                <DrugLogEdit
-                    otc={getMedicineRecord(showDrugLog.MedicineId, medicineOtcList)?.OTC || false}
-                    drugName={getMedicineRecord(showDrugLog.MedicineId, medicineOtcList)?.Drug || '[unknown]'}
-                    show={true}
-                    drugLogInfo={showDrugLog}
-                    onHide={() => setShowDrugLog(null)}
-                    onClose={(drugLogRecord) => {
-                        setShowDrugLog(null);
-                        if (drugLogRecord) saveDrugLog(drugLogRecord).then((r) => setToast([r]));
-                    }}
-                />
-            )}
+            <DrugLogEdit
+                drugLogInfo={showDrugLog as DrugLogRecord}
+                drugName={getMedicineRecord(showDrugLog?.MedicineId as number, medicineOtcList)?.Drug || '[unknown]'}
+                onClose={(drugLogRecord) => {
+                    setShowDrugLog(null);
+                    if (drugLogRecord) saveDrugLog(drugLogRecord).then((r) => setToast([r]));
+                }}
+                onHide={() => setShowDrugLog(null)}
+                otc={getMedicineRecord(showDrugLog?.MedicineId as number, medicineOtcList)?.OTC || false}
+                show={showDrugLog !== null}
+            />
 
             {showDeleteDrugLogRecord && (
                 <Confirm.Modal

--- a/src/components/Pages/Modals/DrugLogEdit.tsx
+++ b/src/components/Pages/Modals/DrugLogEdit.tsx
@@ -21,31 +21,21 @@ interface IProps {
  * @returns {JSX.Element | null}
  */
 const DrugLogEdit = (props: IProps): JSX.Element | null => {
-    const [canSave, setCanSave] = useState(false);
-    const [drugLogInfo, setDrugLogInfo] = useState(props.drugLogInfo);
-    const [show, setShow] = useState(props.show);
-    const otc = props.otc;
-    const onClose = props.onClose;
-    const onHide = props.onHide;
-    const title = props.drugName ? 'Log ' + props.drugName.trim() : 'Log Drug';
-    const textInput = useRef<HTMLTextAreaElement>(null);
+    const {otc, onClose, onHide, drugName} = props;
 
-    // Observer for show
+    const [drugLogInfo, setDrugLogInfo] = useState(props.drugLogInfo);
+    useEffect(() => {
+        const drugLogRecord = {...props.drugLogInfo};
+        if (!drugLogRecord.Notes) drugLogRecord.Notes = '';
+        setDrugLogInfo(drugLogRecord);
+    }, [props.drugLogInfo]);
+
+    const [show, setShow] = useState(props.show);
     useEffect(() => {
         setShow(props.show);
     }, [props.show]);
 
-    // Observer for drugInfo
-    useEffect(() => {
-        const drugLogRecord = props.drugLogInfo;
-        // If props.drugLogInfo.Notes is null or empty then make it an empty string
-        if (!drugLogRecord.Notes) {
-            drugLogRecord.Notes = '';
-        }
-        setDrugLogInfo(drugLogRecord);
-    }, [props.drugLogInfo]);
-
-    // Disable the Save button if Notes are empty.
+    const [canSave, setCanSave] = useState(false);
     useEffect(() => {
         const canSave =
             (drugLogInfo &&
@@ -55,6 +45,9 @@ const DrugLogEdit = (props: IProps): JSX.Element | null => {
             false;
         setCanSave(canSave);
     }, [drugLogInfo]);
+
+    const textInput = useRef<HTMLTextAreaElement>(null);
+    const title = drugName ? 'Log ' + drugName.trim() : 'Log Drug';
 
     /**
      * Fires when a text field or checkbox is changing.
@@ -68,11 +61,8 @@ const DrugLogEdit = (props: IProps): JSX.Element | null => {
         if (drugLogInfo !== null) {
             if (isNumber) {
                 const num = parseInt(value as string);
-                if (num <= 0) {
-                    drugLogInfo[name] = null;
-                } else {
-                    drugLogInfo[name] = num;
-                }
+                if (num <= 0) drugLogInfo[name] = null;
+                else drugLogInfo[name] = num;
             } else {
                 drugLogInfo[name] = value;
             }
@@ -82,55 +72,41 @@ const DrugLogEdit = (props: IProps): JSX.Element | null => {
 
     /**
      * Fires when the user clicks on Save or Cancel
-     * @param {React.MouseEvent<HTMLElement>} e Mouse event object
      * @param {boolean} shouldSave True if the user clicked save, otherwise false
      */
-    const handleHide = (e: React.MouseEvent<HTMLElement>, shouldSave: boolean) => {
-        e.preventDefault();
-        if (shouldSave) {
-            const saveDrugLogInfo = {...drugLogInfo} as DrugLogRecord;
-            onClose(saveDrugLogInfo);
-        } else {
-            onClose(null);
-        }
+    const handleHide = (shouldSave: boolean) => {
+        if (shouldSave) onClose({...drugLogInfo});
+        else onClose(null);
         setShow(false);
     };
 
     // Short circuit render if there is no drugLogInfo.
-    if (!drugLogInfo) {
-        return null;
-    }
+    if (!drugLogInfo) return null;
 
     return (
         <Modal
             backdrop="static"
             centered
+            onEntered={() => textInput?.current?.focus()}
             onHide={() => onHide()}
-            onEntered={() => {
-                if (textInput && textInput.current) {
-                    textInput.current.focus();
-                }
-            }}
             show={show}
         >
             <Modal.Header closeButton>
                 <Modal.Title>{title}</Modal.Title>
             </Modal.Header>
-
             <Modal.Body>
                 <Form>
                     <Form.Group as={Row} controlId="drug-log-notes">
                         <Form.Label column md="4">
                             Amount / Notes
                         </Form.Label>
-
                         <Col md="8">
                             <Form.Control
                                 as="textarea"
-                                ref={textInput}
-                                value={drugLogInfo.Notes as string}
                                 name="Notes"
                                 onChange={(e) => handleOnChange(e)}
+                                ref={textInput}
+                                value={drugLogInfo.Notes as string}
                             />
                         </Col>
                     </Form.Group>
@@ -143,10 +119,10 @@ const DrugLogEdit = (props: IProps): JSX.Element | null => {
                                 </Form.Label>
                                 <Col md="8">
                                     <Form.Control
-                                        type="number"
-                                        value={drugLogInfo.Out || undefined}
                                         name="Out"
                                         onChange={(e) => handleOnChange(e, true)}
+                                        type="number"
+                                        value={drugLogInfo.Out || undefined}
                                     />
                                 </Col>
                             </Form.Group>
@@ -157,10 +133,10 @@ const DrugLogEdit = (props: IProps): JSX.Element | null => {
                                 </Form.Label>
                                 <Col md="8">
                                     <Form.Control
-                                        type="number"
-                                        value={drugLogInfo.In || undefined}
                                         name="In"
                                         onChange={(e) => handleOnChange(e, true)}
+                                        type="number"
+                                        value={drugLogInfo.In || undefined}
                                     />
                                 </Col>
                             </Form.Group>
@@ -170,10 +146,10 @@ const DrugLogEdit = (props: IProps): JSX.Element | null => {
             </Modal.Body>
 
             <Modal.Footer>
-                <Button onClick={(e) => handleHide(e, false)} variant="secondary">
+                <Button onClick={() => handleHide(false)} variant="secondary">
                     Cancel
                 </Button>
-                <Button disabled={!canSave} onClick={(e) => handleHide(e, true)} variant="primary">
+                <Button disabled={!canSave} onClick={() => handleHide(true)} variant="primary">
                     Save changes
                 </Button>
             </Modal.Footer>

--- a/src/components/Pages/Modals/PillboxEdit.tsx
+++ b/src/components/Pages/Modals/PillboxEdit.tsx
@@ -9,8 +9,8 @@ import {clientFullName} from 'utility/common';
 
 interface IProps {
     clientRecord: ClientRecord;
-    pillboxInfo: PillboxRecord;
     onClose: (r: PillboxRecord | null) => void;
+    pillboxInfo: PillboxRecord;
     show: boolean;
 }
 
@@ -20,35 +20,25 @@ interface IProps {
  * @returns {JSX.Element | null}
  */
 const PillboxEdit = (props: IProps): JSX.Element | null => {
-    const clientRecord = props.clientRecord;
-    const [canSave, setCanSave] = useState(false);
-    const [pillboxInfo, setPillboxInfo] = useState<PillboxRecord>(props.pillboxInfo);
-    const [show, setShow] = useState(props.show);
-    const textInput = useRef<HTMLInputElement>(null);
+    const {clientRecord, onClose} = props;
 
-    // Observer for show
+    const [pillboxInfo, setPillboxInfo] = useState<PillboxRecord>(props.pillboxInfo);
+    useEffect(() => {
+        setPillboxInfo({...props.pillboxInfo});
+    }, [props.pillboxInfo]);
+
+    const [show, setShow] = useState(props.show);
     useEffect(() => {
         setShow(props.show);
     }, [props.show]);
 
-    // Observer/mutator for pillboxInfo
+    const [canSave, setCanSave] = useState(false);
     useEffect(() => {
-        const info = {...props.pillboxInfo};
-        setPillboxInfo(info);
-    }, [props.pillboxInfo]);
-
-    // Disable the Save button if the Pillbox name is empty.
-    useEffect(() => {
-        // Is the Name field populated?
-        if (pillboxInfo?.Name.length > 0) {
-            // If any elements have an is-invalid class marker or the fill date is incomplete/ invalid
-            // then don't allow a save.
-            const isInvalidClasses = document.querySelectorAll('.is-invalid');
-            setCanSave(isInvalidClasses.length === 0);
-        } else {
-            setCanSave(false);
-        }
+        if (pillboxInfo?.Name?.length > 0) setCanSave(document.querySelectorAll('.is-invalid')?.length === 0);
+        else setCanSave(false);
     }, [pillboxInfo, setCanSave]);
+
+    const textInput = useRef<HTMLInputElement>(null);
 
     /**
      * Fires when a text field or checkbox is changing.
@@ -64,23 +54,16 @@ const PillboxEdit = (props: IProps): JSX.Element | null => {
 
     /**
      * Fires when the user clicks on save or cancel
-     * @param {React.MouseEvent<HTMLElement>} e Mouse event object
      * @param {boolean} shouldSave True if the user clicked the save button, otherwise false
      */
-    const handleHide = (e: React.MouseEvent<HTMLElement>, shouldSave: boolean) => {
-        e.preventDefault();
-        if (shouldSave) {
-            props.onClose({...pillboxInfo});
-        } else {
-            props.onClose(null);
-        }
+    const handleHide = (shouldSave: boolean) => {
+        if (shouldSave) onClose({...pillboxInfo});
+        else onClose(null);
         setShow(false);
     };
 
     // Short circuit render if there is no drugInfo record.
-    if (!pillboxInfo) {
-        return null;
-    }
+    if (!pillboxInfo) return null;
 
     const titleType = pillboxInfo.Id ? 'Edit Pillbox ' : ('Add Pillbox ' as string);
     const fullName = clientFullName(clientRecord);
@@ -104,16 +87,15 @@ const PillboxEdit = (props: IProps): JSX.Element | null => {
                         <Form.Label column sm="2" style={{userSelect: 'none'}}>
                             Pillbox Name
                         </Form.Label>
-
                         <Col sm="4">
                             <Form.Control
                                 className={pillboxInfo.Name !== '' ? '' : 'is-invalid'}
-                                ref={textInput}
-                                type="text"
-                                value={pillboxInfo.Name}
                                 name="Name"
                                 onChange={(e) => handleOnChange(e)}
+                                ref={textInput}
                                 required
+                                type="text"
+                                value={pillboxInfo.Name}
                             />
                             <div className="invalid-feedback">Pillbox Name field cannot be blank.</div>
                         </Col>
@@ -123,14 +105,13 @@ const PillboxEdit = (props: IProps): JSX.Element | null => {
                         <Form.Label column sm="2" style={{userSelect: 'none'}}>
                             Notes
                         </Form.Label>
-
                         <Col sm="9">
                             <Form.Control
                                 as="textarea"
-                                rows={3}
-                                value={pillboxInfo.Notes ? pillboxInfo.Notes : ''}
                                 name="Notes"
                                 onChange={(e) => handleOnChange(e)}
+                                rows={3}
+                                value={pillboxInfo.Notes ? pillboxInfo.Notes : ''}
                             />
                         </Col>
                     </Form.Group>
@@ -138,10 +119,10 @@ const PillboxEdit = (props: IProps): JSX.Element | null => {
             </Modal.Body>
 
             <Modal.Footer>
-                <Button onClick={(e) => handleHide(e, false)} variant="secondary">
+                <Button onClick={() => handleHide(false)} variant="secondary">
                     Cancel
                 </Button>
-                <Button disabled={!canSave} onClick={(e) => handleHide(e, true)} variant={'primary'}>
+                <Button disabled={!canSave} onClick={() => handleHide(true)} variant={'primary'}>
                     Save changes
                 </Button>
             </Modal.Footer>

--- a/src/components/Pages/Modals/ResidentEdit.tsx
+++ b/src/components/Pages/Modals/ResidentEdit.tsx
@@ -4,7 +4,6 @@ import Form from 'react-bootstrap/Form';
 import Modal from 'react-bootstrap/Modal';
 import Row from 'react-bootstrap/Row';
 import React, {useEffect, useRef, useState} from 'reactn';
-
 import {ClientRecord} from 'types/RecordTypes';
 import {isDateFuture, isDayValid, isMonthValid, isYearValid} from 'utility/common';
 
@@ -20,9 +19,22 @@ interface IProps {
  * @returns {JSX.Element | null}
  */
 const ResidentEdit = (props: IProps): JSX.Element | null => {
-    const [canSave, setCanSave] = useState(true);
     const [residentInfo, setResidentInfo] = useState<ClientRecord>(props.residentInfo);
+    useEffect(() => {
+        if (props.residentInfo) setResidentInfo({...props.residentInfo});
+    }, [props.residentInfo]);
+
     const [show, setShow] = useState(props.show);
+    useEffect(() => {
+        setShow(props.show);
+    }, [props.show]);
+
+    const [canSave, setCanSave] = useState(true);
+    useEffect(() => {
+        setCanSave(document.querySelectorAll('.is-invalid')?.length === 0);
+    }, [residentInfo, setResidentInfo]);
+
+    const onClose = props.onClose;
     const focusRef = useRef<HTMLInputElement>(null);
 
     /**
@@ -39,20 +51,19 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
 
     /**
      * Fires when the user clicks on save or cancel
-     * @param {React.MouseEvent<HTMLElement>} e Mouse event object
      * @param {boolean} shouldSave Set to true if the user clicked the save button, otherwise false
      */
-    const handleHide = (e: React.MouseEvent<HTMLElement>, shouldSave: boolean) => {
-        e.preventDefault();
-        if (shouldSave) {
-            props.onClose({...residentInfo});
-        } else {
-            props.onClose(null);
-        }
+    const handleHide = (shouldSave: boolean) => {
+        if (shouldSave) onClose({...residentInfo});
+        else onClose(null);
         setShow(false);
     };
 
-    const isDobValid = () => {
+    /**
+     * Verify the DOB
+     * @returns {boolean} true if valid, otherwise false
+     */
+    const isDobValid = (): boolean => {
         const dobYear = residentInfo.DOB_YEAR.toString();
         const dobMonth = residentInfo.DOB_MONTH.toString();
         const dobDay = residentInfo.DOB_DAY.toString();
@@ -74,30 +85,10 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
         }
     };
 
-    // Observer for show
-    useEffect(() => {
-        setShow(props.show);
-    }, [props.show]);
-
-    // Observer for residentInfo property
-    useEffect(() => {
-        if (props.residentInfo) {
-            setResidentInfo({...props.residentInfo});
-        }
-    }, [props.residentInfo]);
-
-    // Anytime the fields change check if we have any invalid entries
-    useEffect(() => {
-        const isInvalidClasses = document.querySelectorAll('.is-invalid');
-        setCanSave(isInvalidClasses.length === 0);
-    }, [residentInfo, setResidentInfo]);
-
     // Prevent render if there is no data.
-    if (!residentInfo) {
-        return null;
-    }
+    if (!residentInfo) return null;
 
-    const residentTitle = residentInfo.Id ? 'Edit Resident' : 'Add New Resident';
+    const residentTitle = residentInfo.Id ? 'Edit Client' : 'Add New Client';
 
     return (
         <Modal backdrop="static" centered onEntered={() => focusRef?.current?.focus()} show={show} size="lg">
@@ -114,12 +105,12 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
                         <Col sm="7">
                             <Form.Control
                                 className={residentInfo.FirstName !== '' ? '' : 'is-invalid'}
-                                type="text"
-                                value={residentInfo.FirstName}
                                 name="FirstName"
                                 onChange={(e) => handleOnChange(e)}
                                 ref={focusRef}
                                 required
+                                type="text"
+                                value={residentInfo.FirstName}
                             />
                             <div className="invalid-feedback">First name can not be blank.</div>
                         </Col>
@@ -132,11 +123,11 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
                         <Col sm="7">
                             <Form.Control
                                 className={residentInfo.LastName !== '' ? '' : 'is-invalid'}
-                                type="text"
-                                value={residentInfo.LastName}
                                 name="LastName"
                                 onChange={(e) => handleOnChange(e)}
                                 required
+                                type="text"
+                                value={residentInfo.LastName}
                             />
                             <div className="invalid-feedback">Last name can not be blank.</div>
                         </Col>
@@ -148,11 +139,11 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
                         </Form.Label>
                         <Col sm="7">
                             <Form.Control
-                                type="text"
-                                value={residentInfo.Nickname}
                                 name="Nickname"
                                 onChange={(e) => handleOnChange(e)}
                                 required
+                                type="text"
+                                value={residentInfo.Nickname}
                             />
                         </Col>
                     </Form.Group>
@@ -165,11 +156,11 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
                         <Col sm="2">
                             <Form.Control
                                 className={isMonthValid(residentInfo.DOB_MONTH.toString()) ? '' : 'is-invalid'}
-                                type="text"
-                                value={residentInfo.DOB_MONTH}
                                 name="DOB_MONTH"
                                 onChange={(e) => handleOnChange(e)}
                                 required
+                                type="text"
+                                value={residentInfo.DOB_MONTH}
                             />
                             <div className="invalid-feedback">Enter the month (1-12).</div>
                         </Col>
@@ -184,11 +175,11 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
                                         ? ''
                                         : 'is-invalid'
                                 }
-                                type="text"
-                                value={residentInfo.DOB_DAY}
                                 name="DOB_DAY"
                                 onChange={(e) => handleOnChange(e)}
                                 required
+                                type="text"
+                                value={residentInfo.DOB_DAY}
                             />
                             <div className="invalid-feedback">Enter a valid day.</div>
                         </Col>
@@ -198,15 +189,16 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
                         <Col sm={3}>
                             <Form.Control
                                 className={isYearValid(residentInfo.DOB_YEAR.toString(), true) ? '' : 'is-invalid'}
-                                type="text"
-                                value={residentInfo.DOB_YEAR}
                                 name="DOB_YEAR"
                                 onChange={(e) => handleOnChange(e)}
                                 required
+                                type="text"
+                                value={residentInfo.DOB_YEAR}
                             />
                             <div className="invalid-feedback">Enter a valid birth year.</div>
                         </Col>
                     </Form.Group>
+
                     <Form.Group as={Row}>
                         <Form.Label column sm="2">
                             Notes
@@ -214,11 +206,11 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
                         <Col sm={9}>
                             <Form.Control
                                 as="textarea"
-                                rows={4}
-                                value={residentInfo.Notes}
+                                className={residentInfo?.Notes?.trim().length > 500 ? 'is-invalid' : ''}
                                 name="Notes"
                                 onChange={(e) => handleOnChange(e)}
-                                className={residentInfo?.Notes?.trim().length > 500 ? 'is-invalid' : ''}
+                                rows={4}
+                                value={residentInfo.Notes}
                             />
                             <div className="invalid-feedback">
                                 Notes can only be 500 characters long. length={residentInfo?.Notes?.trim().length}
@@ -229,10 +221,10 @@ const ResidentEdit = (props: IProps): JSX.Element | null => {
             </Modal.Body>
 
             <Modal.Footer>
-                <Button onClick={(e) => handleHide(e, false)} variant="secondary">
+                <Button onClick={() => handleHide(false)} variant="secondary">
                     Cancel
                 </Button>
-                <Button disabled={!canSave} onClick={(e) => handleHide(e, true)} variant="primary">
+                <Button disabled={!canSave} onClick={() => handleHide(true)} variant="primary">
                     Save changes
                 </Button>
             </Modal.Footer>


### PR DESCRIPTION
- Consolidated `const` declarations into logical groups with their associated `useEffect()` underneath.
- Simplified `if` constructs
- Each modal can be rendered without surrounding conditionals
- Fixed a :bug: where PillboxListGroup wasn't rendering for clients that didn't have an existing pillbox

Unrelated:

- package.json `lint` script changed to use `eslint`

Closes #237