### PR TITLE
🐛 bug Unrecognized props on React Components

### DIFF
--- a/src/components/Pages/Buttons/ClientDobButton.tsx
+++ b/src/components/Pages/Buttons/ClientDobButton.tsx
@@ -21,6 +21,10 @@ type TProps = Modify<
     }
 >;
 
+interface IDropdownProps extends DropdownButtonProps {
+    clientRecord: unknown;
+}
+
 /**
  * ClientDobButton is a dropdown button that displays the date of birth of the given client record
  * The dropdown shows the client notes if they have any.
@@ -38,6 +42,9 @@ const ClientDobButton = (props: TProps) => {
         )
     } = props;
 
+    const dropdownProps = {...(props as IDropdownProps)};
+    delete dropdownProps.clientRecord;
+
     /**
      * CSS Style override for getting the Dropdown.ItemText to display correctly
      * @param {React.MouseEvent<HTMLElement>} e Mouse event object
@@ -47,8 +54,8 @@ const ClientDobButton = (props: TProps) => {
      */
     return (
         <DropdownButton
-            {...props}
-            disabled={disabled || clientRecord.Notes == null || clientRecord?.Notes?.trim().length === 0}
+            {...dropdownProps}
+            disabled={disabled || clientRecord?.Notes == null || clientRecord?.Notes?.trim().length === 0}
             id="client-dob-dropdown-button"
             onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
             title={title}
@@ -58,7 +65,7 @@ const ClientDobButton = (props: TProps) => {
                 <Dropdown.Header>
                     <h5>Notes</h5>
                 </Dropdown.Header>
-                <Dropdown.ItemText>{clientRecord.Notes}</Dropdown.ItemText>
+                <Dropdown.ItemText>{clientRecord?.Notes}</Dropdown.ItemText>
             </Dropdown.Item>
         </DropdownButton>
     );

--- a/src/components/Pages/Grids/CheckoutGrid.tsx
+++ b/src/components/Pages/Grids/CheckoutGrid.tsx
@@ -16,6 +16,12 @@ interface IProps extends TableProps {
     medicineList: MedicineRecord[];
 }
 
+interface ITableProps extends TableProps {
+    drugId: unknown;
+    drugLog: unknown;
+    medicineList: unknown;
+}
+
 /**
  * Checkout Grid
  * @param {IProps} props The props for this component
@@ -113,8 +119,13 @@ const CheckoutGrid = (props: IProps): JSX.Element => {
         );
     };
 
+    const tableProps = {...(props as ITableProps)};
+    delete tableProps.drugId;
+    delete tableProps.drugLog;
+    delete tableProps.medicineList;
+
     return (
-        <Table style={{wordWrap: 'break-word'}} {...props} className={'w-auto'} striped bordered hover size="sm">
+        <Table style={{wordWrap: 'break-word'}} {...tableProps} className={'w-auto'} striped bordered hover size="sm">
             <thead>
                 <tr>
                     <th>Drug</th>

--- a/src/components/Pages/Grids/DrugLogGrid.tsx
+++ b/src/components/Pages/Grids/DrugLogGrid.tsx
@@ -31,6 +31,17 @@ interface IProps extends TableProps {
     onPillClick?: (n: number) => void;
 }
 
+interface ITableProps extends TableProps {
+    checkoutOnly: unknown;
+    columns: unknown;
+    condensed: unknown;
+    drugId: unknown;
+    gridLists: unknown;
+    onDelete: unknown;
+    onEdit: unknown;
+    onPillClick: unknown;
+}
+
 /**
  * DrugLogGrid
  * @param {IProps} props The props for this component
@@ -185,10 +196,20 @@ const DrugLogGrid = (props: IProps): JSX.Element => {
         );
     };
 
+    const tableProps = {...(props as ITableProps)};
+    delete tableProps.checkoutOnly;
+    delete tableProps.columns;
+    delete tableProps.condensed;
+    delete tableProps.drugId;
+    delete tableProps.gridLists;
+    delete tableProps.onDelete;
+    delete tableProps.onEdit;
+    delete tableProps.onPillClick;
+
     return (
         <Table
             style={{wordWrap: 'break-word'}}
-            {...props}
+            {...tableProps}
             bordered
             className={condensed !== 'false' ? 'w-auto' : ''}
             hover

--- a/src/components/Pages/Grids/PillboxItemGrid.tsx
+++ b/src/components/Pages/Grids/PillboxItemGrid.tsx
@@ -13,6 +13,11 @@ interface IProps extends TableProps {
     pillboxGridItems: PillRowType[];
 }
 
+interface ITableProps extends TableProps {
+    onEdit: unknown;
+    pillboxGridItems: unknown;
+}
+
 /**
  * PillboxItemGrid
  * @param {IProps} props The props for this component
@@ -131,8 +136,12 @@ const PillboxItemGrid = (props: IProps): JSX.Element | null => {
         );
     };
 
+    const tableProps = {...props} as ITableProps;
+    delete tableProps.onEdit;
+    delete tableProps.pillboxGridItems;
+
     return (
-        <Table style={{wordWrap: 'break-word'}} {...props} bordered hover size="sm" striped>
+        <Table style={{wordWrap: 'break-word'}} {...tableProps} bordered hover size="sm" striped>
             <thead>
                 <tr>
                     <th>Drug</th>

--- a/src/components/Pages/Modals/Confirm.tsx
+++ b/src/components/Pages/Modals/Confirm.tsx
@@ -15,6 +15,14 @@ interface IProps extends ModalProps {
     yesButtonProps?: ButtonProps;
 }
 
+interface IModalProps extends ModalProps {
+    noButtonContent: unknown;
+    noButtonProps: unknown;
+    onSelect: unknown;
+    yesButtonContent: unknown;
+    yesButtonProps: unknown;
+}
+
 /**
  * Confirmation Modal "inheriting" (read composition) from the Modal component
  * Uses Reacts' "dot notation"
@@ -53,8 +61,15 @@ const Confirm = {
             onSelect(isAccepted);
         };
 
+        const modalProps = {...props} as IModalProps;
+        delete modalProps.noButtonContent;
+        delete modalProps.noButtonProps;
+        delete modalProps.onSelect;
+        delete modalProps.yesButtonContent;
+        delete modalProps.yesButtonProps;
+
         return (
-            <Modal {...props} show={show} size={size} backdrop={backdrop} centered>
+            <Modal {...modalProps} show={show} size={size} backdrop={backdrop} centered>
                 {props.children}
                 <Modal.Footer>
                     <Button {...yesButtonProps} onClick={() => onAnswer(true)}>


### PR DESCRIPTION
- Components that extend react-bootstrap were passing non-standard props into the component
- Resolution was to create a separate prop object deleting the non-standard props

See: https://stackoverflow.com/questions/54468535/how-to-solve-warning-react-does-not-recognize-the-x-prop-on-a-dom-element

Closes #264