### PR TITLE
🐛 bug MedicineEdit Drug field showing 'no suggestions' when it shouldn't

### DIFF
--- a/src/components/Pages/Buttons/DrugNameDropdown.tsx
+++ b/src/components/Pages/Buttons/DrugNameDropdown.tsx
@@ -125,7 +125,7 @@ const DrugNameDropdown = (props: IProps) => {
             >
                 {filteredDrugNames.length > 0
                     ? filteredDrugNames.map((d) => DrugNameItems(d, false))
-                    : DrugNameItems('no suggestions..', true)}
+                    : ['no suggestions..'].map((s) => DrugNameItems(s, true))}
             </CustomMenu>
         </Dropdown>
     );


### PR DESCRIPTION
- Fixed 🔧 by using `map()` to load the 'no suggestions...' dropdown item

Closes #276