### PR TITLE
🐛 bug Clicking close button on MedicineEdit did not close the modal

### DIFF
--- a/src/components/Pages/Modals/MedicineEdit.tsx
+++ b/src/components/Pages/Modals/MedicineEdit.tsx
@@ -174,7 +174,9 @@ const MedicineEdit = (props: IProps): JSX.Element | null => {
             show={show}
             size="lg"
         >
-            <Modal.Header closeButton>{modalTitle}</Modal.Header>
+            <Modal.Header onHide={() => onClose(null)} closeButton>
+                {modalTitle}
+            </Modal.Header>
 
             <Modal.Body>
                 <Form>


### PR DESCRIPTION
- Fixed 🔧 by adding an `onHide()` attribute to `<Modal.Header>`

Closes #274