### PR TITLE
🚅 Client Load performance 

### DIFF
--- a/src/components/Pages/ClientPage.tsx
+++ b/src/components/Pages/ClientPage.tsx
@@ -27,7 +27,6 @@ const ClientPage = (props: IProps): JSX.Element | null => {
     const [activeClient, setActiveClient] = useGlobal('activeClient');
     const [clientList, setClientList] = useGlobal('clientList');
     const [filteredClients, setFilteredClients] = useState<ClientRecord[]>(clientList);
-    const [mm] = useGlobal('medicineManager');
     const [cm] = useGlobal('clientManager');
     const [searchIsValid, setSearchIsValid] = useState(false);
     const [searchText, setSearchText] = useState('');
@@ -74,16 +73,16 @@ const ClientPage = (props: IProps): JSX.Element | null => {
      * @param {ClientRecord} clientRecord A ClientRecord object to set as the activeClient.clientInfo
      */
     const handleOnSelected = (clientRecord?: ClientRecord) => {
-        const refreshClient = async (clientRec: ClientRecord): Promise<void> => {
-            const clientId = clientRec.Id as number;
+        const refreshClient = async (clientId: number): Promise<void> => {
+            const clientLoad = await cm.loadClient(clientId);
             try {
                 await setActiveClient({
                     ...activeClient,
-                    drugLogList: await mm.loadDrugLog(clientId, 5),
-                    medicineList: await mm.loadMedicineList(clientId),
-                    pillboxItemList: await mm.loadPillboxItemList(clientId),
-                    pillboxList: await mm.loadPillboxList(clientId),
-                    clientInfo: clientRec
+                    clientInfo: clientLoad.clientInfo,
+                    drugLogList: clientLoad.drugLogList,
+                    medicineList: clientLoad.medicineList,
+                    pillboxList: clientLoad.pillboxList,
+                    pillboxItemList: clientLoad.pillboxItemList
                 });
             } catch (e) {
                 await setErrorDetails(e);
@@ -91,7 +90,7 @@ const ClientPage = (props: IProps): JSX.Element | null => {
         };
 
         if (clientRecord) {
-            refreshClient(clientRecord)
+            refreshClient(clientRecord.Id as number)
                 .then(() => onSelected())
                 .then(() => setSearchText(''));
         } else {

--- a/src/components/Pages/DiagnosticPage.tsx
+++ b/src/components/Pages/DiagnosticPage.tsx
@@ -1,7 +1,7 @@
 import Alert from 'react-bootstrap/Alert';
 import Button, {ButtonProps} from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
-import React, {useEffect, useGlobal, useMemo, useState} from 'reactn';
+import React, {useGlobal, useMemo, useState} from 'reactn';
 import {ReactNode} from 'reactn/default';
 import {randomString} from 'utility/common';
 
@@ -52,15 +52,6 @@ const DiagnosticPage = (props: IProps): JSX.Element | null => {
     const getText = async (response: Response) => {
         return await response.text();
     };
-
-    // Observer to show / hide the Diagnostics tab title
-    useEffect(() => {
-        const el = document.getElementById('landing-page-tabs-tab-error');
-        if (el) {
-            if (error) el.style.color = '#007BFF';
-            else el.style.color = 'white';
-        }
-    }, [error]);
 
     /**
      * Use memoization, so we don't have 3000 re-renders when an error occurs.

--- a/src/components/Pages/LandingPage.tsx
+++ b/src/components/Pages/LandingPage.tsx
@@ -1,7 +1,8 @@
 import ClientPage from 'components/Pages/ClientPage';
 import Tab from 'react-bootstrap/Tab';
 import Tabs from 'react-bootstrap/Tabs';
-import React, {useGlobal, useMemo} from 'reactn';
+import ToggleButton from 'react-bootstrap/ToggleButton';
+import React, {useGlobal, useMemo, useEffect} from 'reactn';
 import {ReactNode} from 'reactn/default';
 import DiagnosticPage from './DiagnosticPage';
 import LoginPage from './LoginPage';
@@ -30,6 +31,26 @@ const LandingPage = () => {
     const navBarElement = document.getElementsByClassName('nav nav-tabs');
     if (navBarElement?.length > 0) navBarElement[0].classList.add('d-print-none');
 
+    // Observer to show / hide the Diagnostics tab title
+    useEffect(() => {
+        const el = document.getElementById('landing-page-tabs-tab-error');
+        if (el) {
+            if (errorDetails) el.style.display = 'block';
+            else el.style.display = 'none';
+        }
+    }, [errorDetails]);
+
+    // Observer to show / hide tabs based on if logged in and if a client has been selected
+    useEffect(() => {
+        ['resident', 'medicine', 'manage', 'manage-otc'].map((tab) => {
+            const el = document.getElementById('landing-page-tabs-tab-' + tab);
+            if (el) {
+                if (tab === 'resident' || tab === 'manage-otc') el.style.display = apiKey ? 'block' : 'none';
+                else el.style.display = apiKey && activeClient ? 'block' : 'none';
+            }
+        });
+    }, [activeClient, apiKey]);
+
     /**
      * Memoized pages to reduce number of re-renders
      */
@@ -54,7 +75,20 @@ const LandingPage = () => {
      * @param {ITitleProps} props The props for this component
      */
     const Title = (props: ITitleProps) => {
-        return <span className={activeTabKey === props.activeKey ? 'bld' : undefined}>{props.children}</span>;
+        const {activeKey, children} = props;
+        return (
+            <ToggleButton
+                className={activeKey === activeTabKey ? 'bld' : undefined}
+                size="sm"
+                type="radio"
+                value={activeKey}
+                checked={activeKey === activeTabKey}
+                variant="outline-info"
+            >
+                {' '}
+                {children}
+            </ToggleButton>
+        );
     };
 
     return (
@@ -85,7 +119,9 @@ const LandingPage = () => {
                 </Tab.Content>
             </Tab>
             <Tab disabled={!errorDetails} eventKey="error" title={<Title activeKey="error">Diagnostics</Title>}>
-                <DiagnosticPage error={errorDetails} dismissErrorAlert={() => window.location.reload()} />
+                <Tab.Content>
+                    <DiagnosticPage error={errorDetails} dismissErrorAlert={() => window.location.reload()} />
+                </Tab.Content>
             </Tab>
         </Tabs>
     );

--- a/src/components/Pages/LandingPage.tsx
+++ b/src/components/Pages/LandingPage.tsx
@@ -79,7 +79,7 @@ const LandingPage = () => {
         return (
             <ToggleButton
                 className={activeKey === activeTabKey ? 'bld' : undefined}
-                size="sm"
+                size="lg"
                 type="radio"
                 value={activeKey}
                 checked={activeKey === activeTabKey}

--- a/src/managers/ClientManager.ts
+++ b/src/managers/ClientManager.ts
@@ -1,4 +1,5 @@
 import {IClientProvider} from 'providers/ClientProvider';
+import {TClient} from 'reactn/default';
 import {ClientRecord} from 'types/RecordTypes';
 import {asyncWrapper} from 'utility/common';
 
@@ -7,6 +8,7 @@ type DeleteResponse = {success: boolean};
 export interface IClientManager {
     deleteClient: (clientId: number) => Promise<boolean>;
     loadClientList: () => Promise<ClientRecord[]>;
+    loadClient: (clientId: number) => Promise<TClient>;
     updateClient: (r: ClientRecord) => Promise<ClientRecord>;
 }
 
@@ -21,6 +23,16 @@ const ClientManager = (clientProvider: IClientProvider): IClientManager => {
      */
     const _updateClient = async (clientRecord: ClientRecord): Promise<ClientRecord> => {
         const [e, r] = (await asyncWrapper(clientProvider.post(clientRecord))) as [unknown, Promise<ClientRecord>];
+        if (e) throw e;
+        else return r;
+    };
+
+    /**
+     * Loads the Client object
+     * @param {number} clientId The PK of the client
+     */
+    const _loadClient = async (clientId: number) => {
+        const [e, r] = (await asyncWrapper(clientProvider.load(clientId))) as [unknown, Promise<TClient>];
         if (e) throw e;
         else return r;
     };
@@ -53,9 +65,12 @@ const ClientManager = (clientProvider: IClientProvider): IClientManager => {
         else return r;
     };
 
-    return {
+    return <IClientManager>{
         deleteClient: async (clientId: number): Promise<boolean> => {
             return await _deleteClient(clientId);
+        },
+        loadClient: async (clientId: number): Promise<TClient> => {
+            return await _loadClient(clientId);
         },
         loadClientList: async (): Promise<ClientRecord[]> => {
             return await _loadClientList();

--- a/src/providers/ClientProvider.ts
+++ b/src/providers/ClientProvider.ts
@@ -1,19 +1,26 @@
 import Frak from 'frak/lib/components/Frak';
+import {TClient} from 'reactn/default';
 import {ClientRecord} from 'types/RecordTypes';
 
 export interface IClientProvider {
-    setApiKey: (apiKey: string) => void;
-    search: (options: Record<string, unknown>) => Promise<ClientRecord[]>;
-    restore: (residentId: number) => Promise<ClientRecord>;
-    read: (id: number) => Promise<ClientRecord>;
-    post: (residentInfo: ClientRecord) => Promise<ClientRecord>;
     delete: (residentId: number) => Promise<DeleteResponse>;
+    load: (clientId: number) => Promise<TClient>;
+    post: (residentInfo: ClientRecord) => Promise<ClientRecord>;
+    read: (id: number) => Promise<ClientRecord>;
+    restore: (residentId: number) => Promise<ClientRecord>;
+    search: (options: Record<string, unknown>) => Promise<ClientRecord[]>;
+    setApiKey: (apiKey: string) => void;
 }
 
 type DeleteResponse = {success: boolean};
 type RecordResponse = {
     data: ClientRecord[] | ClientRecord;
     status: number;
+    success: boolean;
+};
+
+type LoadResponse = {
+    data: TClient;
     success: boolean;
 };
 
@@ -109,6 +116,21 @@ const ClientProvider = (url: string): IClientProvider => {
             const response = await _frak.delete<DeleteResponse>(uri);
             if (response.success) {
                 return response;
+            } else {
+                throw response;
+            }
+        },
+
+        /**
+         * Load all Client info as TClient type
+         * @param {number} clientId PK of the Client
+         * @returns {Promise<TClient>}
+         */
+        load: async (clientId: number): Promise<TClient> => {
+            const uri = _baseUrl + 'client-load/' + clientId + '?api_key=' + _apiKey;
+            const response = await _frak.get<LoadResponse>(uri);
+            if (response.success) {
+                return response.data;
             } else {
                 throw response;
             }


### PR DESCRIPTION
⛲ feat Client Load

- When a client is selected the `activeClient` is now bulk loaded with all medicine, med-logs, pillboxes, and pillbox items

- **Note**: This requires the deployment of rxchart-app 

Unrelated:

- 👗 style LandingPage tabs are now larger per Stephen's request