### PR TITLE
🐛 bug Prevent saving in DrugLogEdit when Amount/Notes is a literal "0"

### DIFF
--- a/src/components/Pages/Modals/DrugLogEdit.tsx
+++ b/src/components/Pages/Modals/DrugLogEdit.tsx
@@ -38,7 +38,7 @@ const DrugLogEdit = (props: IProps): JSX.Element | null => {
     useEffect(() => {
         const canSave =
             (drugLogInfo &&
-                ((drugLogInfo.Notes && drugLogInfo.Notes.length > 0) ||
+                ((drugLogInfo.Notes && drugLogInfo.Notes.length > 0 && drugLogInfo.Notes !== '0') ||
                     (drugLogInfo.In && drugLogInfo.In > 0) ||
                     (drugLogInfo.Out && drugLogInfo.Out > 0))) ||
             false;


### PR DESCRIPTION
Closes #303