### PR TITLE
🐛 bug OTC drugs were not appearing in the drug log grid in the History tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   },
   "browserslist": {
     "production": [
-      "not ie <= 11",
       ">0.2%",
       "not dead",
-      "not op_mini all"
+      "not op_mini all",
+      "not ie <= 11"
     ],
     "development": [
       "last 1 chrome version",

--- a/src/components/Pages/Grids/DrugLogHistoryGrid.tsx
+++ b/src/components/Pages/Grids/DrugLogHistoryGrid.tsx
@@ -19,6 +19,7 @@ interface IProps {
     onDelete: (r: DrugLogRecord) => void;
     onEdit: (r: DrugLogRecord) => void;
     onPillClick: (pillboxId: number) => void;
+    medicineList: MedicineRecord[]; // Includes OTC
 }
 
 /**
@@ -26,8 +27,8 @@ interface IProps {
  * @param {IProps} props The props for this component
  */
 const DrugLogHistoryGrid = (props: IProps): JSX.Element => {
-    const {activeClient, onDelete, onEdit, onPillClick} = props;
-    const {medicineList, pillboxItemList, pillboxList, drugLogList} = activeClient;
+    const {activeClient, onDelete, onEdit, onPillClick, medicineList} = props;
+    const {pillboxItemList, pillboxList, drugLogList} = activeClient;
 
     /**
      * Returns the value of the drug column for the given drugId

--- a/src/components/Pages/Grids/MedDrugLogHistory.tsx
+++ b/src/components/Pages/Grids/MedDrugLogHistory.tsx
@@ -12,7 +12,7 @@ interface IProps {
     onDelete: (drugLogRecord: DrugLogRecord) => void;
     onEdit: (drugLogRecord: DrugLogRecord) => void;
     onPillClick: (pillboxId: number) => void;
-    otcList: MedicineRecord[];
+    medicineOtcList: MedicineRecord[]; // Includes OTC drugs
     disabled: boolean;
 }
 
@@ -21,7 +21,7 @@ interface IProps {
  * @param {IProps} props The props for this component
  */
 const MedDrugLogHistory = (props: IProps) => {
-    const {activeClient, onDelete, onEdit, onPillClick, disabled} = props;
+    const {activeClient, medicineOtcList, onDelete, onEdit, onPillClick, disabled} = props;
     const [printing, setPrinting] = useState(false);
 
     useEffect(() => {
@@ -76,6 +76,7 @@ const MedDrugLogHistory = (props: IProps) => {
             <div className="mt-3">
                 <DrugLogHistoryGrid
                     activeClient={activeClient}
+                    medicineList={medicineOtcList}
                     onDelete={(drugLogRecord) => onDelete(drugLogRecord)}
                     onEdit={(drugLogRecord) => onEdit(drugLogRecord)}
                     onPillClick={(pillboxId) => onPillClick(pillboxId)}

--- a/src/components/Pages/RxTabs/RxHistory.tsx
+++ b/src/components/Pages/RxTabs/RxHistory.tsx
@@ -61,7 +61,7 @@ const RxHistory = (props: IProps) => {
                 onEdit={(drugLogRecord) => setShowDrugLog({...drugLogRecord})}
                 onDelete={(drugLogRecord) => setShowDeleteDrugLogRecord(drugLogRecord)}
                 onPillClick={(pillboxId) => onPillboxSelected(pillboxId)}
-                otcList={otcList}
+                medicineOtcList={medicineOtcList}
             />
 
             <DrugLogEdit


### PR DESCRIPTION
Problem was the `OtcList` was not being properly passed as a prop to DrugLogHistoryGrid

Unrelated:
- Changed Browserlist in package.json to list "not ie <= 11" last so ESLint would stop pitching a fit

Closes #313